### PR TITLE
Update dependencies (13-04-2022)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jellyfish~=0.8.2
 nltk~=3.5
 spacy~=2.3.1
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz
-klat-connector>=0.6.2a8
+klat-connector>0.6.2a8


### PR DESCRIPTION
More recent klat-connector version to reflect latest chatbots v2 dependencies