### PR TITLE
Add CLI entrypoint to init an MQ bot

### DIFF
--- a/chatbot_core/utils/bot_utils.py
+++ b/chatbot_core/utils/bot_utils.py
@@ -45,7 +45,7 @@ from datetime import datetime
 import yaml
 from klat_connector import start_socket
 
-from chatbot_core.utils.logger import LOG
+from ovos_utils.log import LOG
 
 # Causes circular imports
 # from chatbot_core import ChatBot
@@ -661,7 +661,7 @@ def run_mq_bot(chatbot_name: str, vhost: str = '/chatbots',
     @param init_kwargs: extra kwargs to pass to chatbot `__init__` method
     @returns: Started ChatBotV2 instance
     """
-    from neon_utils.log_utils import LOG, init_log
+    from neon_utils.log_utils import init_log
     init_log({"level_overrides": {"error": ['pika'],
                                   "warning": ["filelock"]}})
     os.environ['CHATBOT_VERSION'] = 'v2'

--- a/chatbot_core/utils/bot_utils.py
+++ b/chatbot_core/utils/bot_utils.py
@@ -46,8 +46,10 @@ import yaml
 from klat_connector import start_socket
 
 from chatbot_core.utils.logger import LOG
+
+# Causes circular imports
 # from chatbot_core import ChatBot
-from chatbot_core.v2 import ChatBot as ChatBotV2
+# from chatbot_core.v2 import ChatBot as ChatBotV2
 
 def get_ip_address():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -650,7 +652,7 @@ def _find_bot_modules():
 
 
 def run_mq_bot(chatbot_name: str, vhost: str = '/chatbots',
-               run_kwargs: dict = None, init_kwargs: dict = None) -> ChatBotV2:
+               run_kwargs: dict = None, init_kwargs: dict = None):
     """
     Get an initialized MQ Chatbot instance
     @param chatbot_name: chatbot entrypoint name and configuration key

--- a/chatbot_core/utils/bot_utils.py
+++ b/chatbot_core/utils/bot_utils.py
@@ -661,6 +661,9 @@ def run_mq_bot(chatbot_name: str, vhost: str = '/chatbots',
     @param init_kwargs: extra kwargs to pass to chatbot `__init__` method
     @returns: Started ChatBotV2 instance
     """
+    from neon_utils.log_utils import LOG, init_log
+    init_log({"level_overrides": {"error": ['pika'],
+                                  "warning": ["filelock"]}})
     os.environ['CHATBOT_VERSION'] = 'v2'
     run_kwargs = run_kwargs or dict()
     init_kwargs = init_kwargs or dict()

--- a/chatbot_core/utils/bot_utils.py
+++ b/chatbot_core/utils/bot_utils.py
@@ -662,8 +662,8 @@ def run_mq_bot(chatbot_name: str, vhost: str = '/chatbots',
     @returns: Started ChatBotV2 instance
     """
     from neon_utils.log_utils import init_log
-    init_log({"level_overrides": {"error": ['pika'],
-                                  "warning": ["filelock"]}})
+    init_log({"logs": {"level_overrides": {"error": ['pika'],
+                                           "warning": ["filelock"]}}})
     os.environ['CHATBOT_VERSION'] = 'v2'
     run_kwargs = run_kwargs or dict()
     init_kwargs = init_kwargs or dict()

--- a/chatbot_core/utils/logger.py
+++ b/chatbot_core/utils/logger.py
@@ -17,20 +17,23 @@
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
-import logging
+from ovos_utils.log import LOG
+LOG.name = "chatbots"
 
 # fmt = '%(asctime)s - %(levelname)-8s - %(name)s:%(filename)s:%(module)s:%(funcName)s:%(lineno)d - %(message)s'
 # logging.basicConfig(level=logging.DEBUG, format=fmt, datefmt='%Y-%m-%d:%H:%M:%S')
-LOG = logging.getLogger("chatbots")
+# LOG = logging.getLogger("chatbots")
 # logging.getLogger("socketio.client").setLevel(logging.WARNING)
 # logging.getLogger("engineio.client").setLevel(logging.WARNING)
 # logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
-def make_logger(name, level=logging.DEBUG):
+def make_logger(name, level=None):
     """
     Create a logger with the specified name (used to create bot loggers)
     """
+    import logging
+    level = level or logging.DEBUG
     logger = logging.getLogger(name)
     logger.setLevel(level)
     return logging.getLogger(name)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setuptools.setup(
     entry_points={'console_scripts': ["start-klat-bots=chatbot_core.utils:cli_start_bots",
                                       "stop-klat-bots=chatbot_core.utils:cli_stop_bots",
                                       "debug-klat-bots=chatbot_core.utils:debug_bots",
-                                      "start-klat-prompter=chatbot_core.utils:cli_start_prompter"]},
+                                      "start-klat-prompter=chatbot_core.utils:cli_start_prompter",
+                                      "start-mq-bot:chatbot_core.utils.cli_start_bot"]},
     install_requires=get_requirements("requirements.txt"),
     extras_requires={"extra-lgpl": get_requirements("extra-lgpl.txt")}
 )

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setuptools.setup(
                                       "stop-klat-bots=chatbot_core.utils:cli_stop_bots",
                                       "debug-klat-bots=chatbot_core.utils:debug_bots",
                                       "start-klat-prompter=chatbot_core.utils:cli_start_prompter",
-                                      "start-mq-bot=chatbot_core.utils.bot_utils:cli_start_bot"]},
+                                      "start-mq-bot=chatbot_core.utils.bot_utils:cli_start_mq_bot"]},
     install_requires=get_requirements("requirements.txt"),
     extras_requires={"extra-lgpl": get_requirements("extra-lgpl.txt")}
 )

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setuptools.setup(
                                       "stop-klat-bots=chatbot_core.utils:cli_stop_bots",
                                       "debug-klat-bots=chatbot_core.utils:debug_bots",
                                       "start-klat-prompter=chatbot_core.utils:cli_start_prompter",
-                                      "start-mq-bot:chatbot_core.utils.cli_start_bot"]},
+                                      "start-mq-bot=chatbot_core.utils:cli_start_bot"]},
     install_requires=get_requirements("requirements.txt"),
     extras_requires={"extra-lgpl": get_requirements("extra-lgpl.txt")}
 )

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setuptools.setup(
                                       "stop-klat-bots=chatbot_core.utils:cli_stop_bots",
                                       "debug-klat-bots=chatbot_core.utils:debug_bots",
                                       "start-klat-prompter=chatbot_core.utils:cli_start_prompter",
-                                      "start-mq-bot=chatbot_core.utils:cli_start_bot"]},
+                                      "start-mq-bot=chatbot_core.utils.bot_utils:cli_start_bot"]},
     install_requires=get_requirements("requirements.txt"),
     extras_requires={"extra-lgpl": get_requirements("extra-lgpl.txt")}
 )


### PR DESCRIPTION
# Description
Adds a CLI method to load an MQ chatbot by Python entrypoint
Performs log init for the added entrypoint but this should happen more generally

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Mostly equivalent to https://github.com/NeonGeckoCom/chatbots/blob/dev/util/v2_utils.py