### PR TITLE
Update dependencies to allow newer releases

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 click~=8.0
-klat-connector==0.6.2a15
+klat-connector~=0.6,>=0.6.2a15
 neon-mq-connector>=0.7.2a9
 neon_utils[network,sentry] >= 1.11.1a6
-ovos-bus-client~=0.0.5
+ovos-bus-client~=0.0,>=0.0.5
 psutil~=5.7


### PR DESCRIPTION
# Description
Update to allow latest klat-connector and ovos-bus-client dependencies

# Issues
- Needed for Python 3.10 Support https://github.com/NeonGeckoCom/chat-facilitator-proctor/pull/9

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->