### PR TITLE
Update MQ init for compat. with klat-connector changes

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 click~=8.0
-klat-connector~=0.6,>=0.6.2a15
+klat-connector~=0.6,>=0.6.2a21
 neon-mq-connector>=0.7.2a9
-neon_utils[network,sentry] >= 1.11.1a6
+neon-utils[network,sentry]~=1.12
 ovos-bus-client~=0.0,>=0.0.5
 psutil~=5.7


### PR DESCRIPTION
# Description
Remove duplicated call to _setup_listeners
Minor logging and default value handling changes to resovle warnings Update requirements


# Issues
- https://github.com/NeonGeckoCom/klat-connector/pull/77 updated the `KlatAPIMQ` class to initialize listeners internally

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->