### PR TITLE
Fixed stopping logic and passing list connected cids on sync

### DIFF
--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -465,4 +465,4 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
     def stop(self):
         self.stop_shout_thread()
-        super().stop()
+        KlatAPIMQ.stop(self)

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -284,7 +284,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.warning(f'{self.nick}: Missing "shout" in received message data: {message_data}')
 
     def _send_state(self):
-        self.send_shout(shout='heartbeat',
+        self.send_shout(shout='chatbot state',
                         context={
                             'version': os.environ.get('SERVICE_VERSION', package_version),
                             'bot_type': self.bot_type,


### PR DESCRIPTION
# Description
- Graceful stopping of shout thread on stopping consumer
- Sending list current conversation ids on sync (helpful if mq chatbots observer gets reconnected to prevent mismatching state)

# Other Notes
- Stopping logic depends on https://github.com/NeonGeckoCom/klat-connector/pull/91