### PR TITLE
Implement conversation history handling for subminds

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
         # TODO: 3.10 and 3.11 need support in klat-connector
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install .[lang] -r requirements/test_requirements.txt
           python -m nltk.downloader punkt_tab
         env:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
         # TODO: 3.10 and 3.11 need support in klat-connector
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -38,7 +38,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9 ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
         # TODO: 3.10 and 3.11 need support in klat-connector
       max-parallel: 1
     runs-on: ubuntu-latest

--- a/chatbot_core/chatbot_abc.py
+++ b/chatbot_core/chatbot_abc.py
@@ -76,11 +76,14 @@ class ChatBotABC(ABC):
         pass
 
     @abstractmethod
-    def on_discussion(self, user: str, shout: str):
+    def on_discussion(self, user: str, shout: str,
+                       prompt_id: Optional[str] = None):
         """
-        Override in any bot to handle discussion from other subminds. This may inform voting for the current prompt
+        Override in any bot to handle discussion from other subminds. 
+        This may inform voting for the current prompt
         :param user: user associated with shout
         :param shout: shout to be considered
+        :param prompt_id: id of prompt being discussed
         """
         pass
 

--- a/chatbot_core/utils/enum.py
+++ b/chatbot_core/utils/enum.py
@@ -18,6 +18,7 @@
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
 from enum import IntEnum
+from neon_data_models.enum import CcaiState as ConversationState
 
 
 class ConversationControls:
@@ -28,15 +29,6 @@ class ConversationControls:
     NEXT = "I'm ready for the next prompt."
     HIST = "history"
     WAIT = " may respond to the next prompt."
-
-
-class ConversationState(IntEnum):
-    IDLE = 0  # No active prompt
-    RESP = 1  # Gathering responses to prompt
-    DISC = 2  # Discussing responses
-    VOTE = 3  # Voting on responses
-    PICK = 4  # Proctor will select response
-    WAIT = 5  # Bot is waiting for the proctor to ask them to respond (not participating)
 
 
 class BotTypes:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -240,13 +240,14 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
         # Initialize prompt data structure if it doesn't exist
         if prompt_id and prompt_id not in self.prompt_to_cid:
+            # TODO: Participants were announced prior to this message
             self.current_conversations.setdefault(cid, {})
             self.current_conversations[cid].setdefault("prompts", {})
             self.current_conversations[cid].setdefault("prompt_history", [])
             if prompt_id not in self.current_conversations[cid]['prompts']:
                 self.current_conversations[cid]['prompts'][prompt_id] = {
                     "bot_name": self.service_name,
-                    "participating_subminds": [],
+                    "participating_subminds": self.current_conversations[cid].pop('next_subminds', []),
                     "cycles": [{
                         "proposed_responses": {},
                         "discussion": [{}],
@@ -270,10 +271,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             if "accepting responses" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.RESP)
-                subminds = message_data.get("participating_subminds", [])
-                self.current_conversations[cid]['prompts'][prompt_id]\
-                    ["participating_subminds"] = subminds
-                self.log.info(f"Participating subminds set to: {subminds}")
             elif "discussing responses" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.DISC)
@@ -296,10 +293,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     self.log.warning(f"Conversation state changed by Proctor "
                                     f"message to {message.prompt_state}")
                     changed = True
-            if prompt_id and ("participating_subminds" in message_data):
-                self.log.info(f"Got participants from: {message_data}")
-            elif prompt_id and ("requested_subminds" in message_data):
-                self.log.info(f"Got requested participants from: {message_data}")
         if changed:
             self.log.info(f"State changed to: "
                           f"{self.get_conversation_state(cid).name}")
@@ -315,6 +308,12 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             if is_message_from_proctor:
                 # Proctor control message
                 # TODO: Can we re-define the proctor to always specify a prompt_id?
+                if "are selected for current prompt" in shout:
+                    next_subminds = shout.split("are selected")[0].split(',')
+                    next_subminds = [s.replace('and', '').strip() for s in next_subminds]
+                    self.log.info(f"Proctor selected next subminds: {next_subminds}")
+                    self.current_conversations.setdefault(cid, {})
+                    self.current_conversations[cid]['next_subminds'] = next_subminds
                 return
             # Non-proctored conversation activity
             self.log.info(f"Non-proctored input: {message}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -244,27 +244,14 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             response['conversation_state'] = conversation_state
             message_sender = BotTypes.PROCTOR
 
-            self.current_conversations.setdefault(cid, {})
-            self.current_conversations[cid].setdefault("prompts", {})
-            self.current_conversations[cid].setdefault("prompt_history", [])
             prompt_id = message_data.get('prompt_id') or \
                 message_data.get('promptID') or ''
-            self.set_conversation_state(cid, conversation_state)
+            # self.set_conversation_state(cid, conversation_state)
             if not prompt_id and conversation_state != ConversationState.IDLE:
                 prompt_id = self.current_conversations[cid]['prompt_history'][-1]
-                self.log.info(f"Inferred prompt_id from history: {prompt_id}")
+                self.log.warning(f"Inferred prompt_id from history: {prompt_id}")
 
-            if prompt_id:
-                # Initialize prompt data structure if it doesn't exist
-                if prompt_id not in self.current_conversations[cid]['prompts']:
-                    self.current_conversations[cid]['prompts'][prompt_id] = {
-                        "proposed_responses": {},
-                        "discussion": [{}],
-                        "votes": {}
-                    }
                 current_prompt = self.current_conversations[cid]['prompts'][prompt_id]
-                self.current_conversations[cid]['prompt_history'].append(prompt_id)
-                self.prompt_to_cid[prompt_id] = cid
 
                 # TODO: Include prompt history in context
                 if conversation_state == ConversationState.RESP:
@@ -328,8 +315,21 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         message = ChatbotsMqRequest(**message_data)
         shout = message.message_text
         cid = message.cid
-        # Refactored to track this internally instead of from message context
-        # conversation_state = ConversationState(message_data.get('conversation_state', 0))
+        prompt_id = message.prompt_id
+
+        # Initialize prompt data structure if it doesn't exist
+        if prompt_id and \
+                self.get_conversation_state(cid) == ConversationState.IDLE:
+            if prompt_id not in self.current_conversations[cid]['prompts']:
+                self.current_conversations[cid]['prompts'][prompt_id] = {
+                    "proposed_responses": {},
+                    "discussion": [{}],
+                    "votes": {}
+                }
+            self.current_conversations[cid]['prompt_history'].append(prompt_id)
+            self.prompt_to_cid[prompt_id] = cid
+            self.log.info(f"Starting new prompt: {prompt_id}")
+
 
         message_sender = message.username
         is_message_from_proctor = self._user_is_proctor(message_sender)
@@ -371,7 +371,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
         # Handle any other message not related to conversation state handling
         conversation_state = self.get_conversation_state(cid)
-        prompt_id = message.prompt_id
 
         if not prompt_id:
             if is_message_from_proctor:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -317,7 +317,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.current_conversations[cid].setdefault("prompt_history", [])
             if prompt_id not in self.current_conversations[cid]['prompts']:
                 self.current_conversations[cid]['prompts'][prompt_id] = {
-                    "prompt": message.message_text,
                     "participating_subminds": [],
                     "proposed_responses": {},
                     "discussion": [{}],
@@ -406,6 +405,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         elif shout:
             # Proctor shout that wasn't already handled(?)
             self.log.info(f"Responding to {message}")
+            if conversation_state == ConversationState.RESP:
+                self.current_conversations[cid]['prompts'][prompt_id]\
+                    ["prompt"] = message.message_text
             response = self.get_chatbot_response(cid=cid, message_data=message_data,
                                                  shout=shout, message_sender=message_sender,
                                                  is_message_from_proctor=is_message_from_proctor,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -251,8 +251,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 prompt_id = self.current_conversations[cid]['prompt_history'][-1]
                 self.log.warning(f"Inferred prompt_id from history: {prompt_id}")
 
+                
+            if prompt_id:
                 current_prompt = self.current_conversations[cid]['prompts'][prompt_id]
-
                 # TODO: Include prompt history in context
                 if conversation_state == ConversationState.RESP:
                     response['shout'] = self.ask_chatbot(user=message_sender,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -359,7 +359,11 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         conversation_state = self.get_conversation_state(cid)
         prompt_id = message.prompt_id
 
-        if prompt_id and not is_message_from_proctor:
+        if not prompt_id:
+            # Non-proctored conversation activity
+            self.log.info(f"Non-proctored input: {message}")
+        elif not is_message_from_proctor:
+            # Submind response in proctored conversation
             self.log.debug(f"Handling non-proctor CCAI message. "
                            f"state={conversation_state}")
             if conversation_state == ConversationState.RESP:
@@ -369,13 +373,21 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             elif conversation_state == ConversationState.VOTE:
                 self.on_vote(prompt_id, shout, message_sender)
         elif conversation_state == ConversationState.PICK:
-                try:
-                    preamble, choice = shout.split(":", 1)
-                    winner = preamble.split(" ")[-1]
-                except ValueError:
-                    self.log.warning(f"Failed to parse winner from: {shout}")
-                    return
-                self.on_selection(prompt_id, winner, choice)
+            # Proctor made a selection
+            try:
+                preamble, choice = shout.split(":", 1)
+                winner = preamble.split(" ")[-1]
+            except ValueError:
+                self.log.warning(f"Failed to parse winner from: {shout}")
+                return
+            self.on_selection(prompt_id, winner, choice)
+        # elif conversation_state == ConversationState.RESP:
+        #     # Proposal phase
+        # elif conversation_state == ConversationState.DISC:
+        #     # Discussion phase
+        # elif conversation_state == ConversationState.VOTE:
+        #     # Voting phase
+
         elif shout:
             response = self.get_chatbot_response(cid=cid, message_data=message_data,
                                                  shout=shout, message_sender=message_sender,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -175,7 +175,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         if self.supports_raw_conversation and \
                 message.requested_participants is None and \
                 self._user_is_proctor(message.username):
-            self.log.info(f"Ignoring targeted message: {message.message_text}")
+            self.log.info(f"Ignoring proctor message: {message.message_text}")
             return
         self.handle_incoming_shout(message.model_dump())
 
@@ -286,7 +286,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     message.prompt_state not in (None, ConversationState.IDLE):
                 old_state = self.get_conversation_state(cid)
                 self.set_conversation_state(cid, message.prompt_state)
-                self.log.warning(f"Conversation state from message data: "
+                self.log.debug(f"Conversation state from message data: "
                                  f"{self.get_conversation_state(cid)}")
                 if self.get_conversation_state(cid) != old_state:
                     self.log.warning(f"Conversation state changed by Proctor "
@@ -370,6 +370,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         if response:
             self.log.info(f"Responding to {message}")
             response = ChatbotsMqSubmindResponse(
+                cid=message.cid,
                 user_id=self.uid,
                 username=self.nick,
                 message_text=response,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -297,7 +297,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         conversation_state = ConversationState(message_data.get('conversation_state', 0))
         message_sender = message_data.get('nick', 'anonymous')
         is_message_from_proctor = self._user_is_proctor(message_sender)
-        if prompt_id := message_data.get("prompt_id") is not None and \
+        if prompt_id := message_data.get("promptID") is not None and \
                 not is_message_from_proctor:
             self.log.info("Handling non-proctor CCAI message")  # TODO: log.debug
             if conversation_state == ConversationState.RESP:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -25,9 +25,10 @@ from neon_mq_connector.utils import RepeatingTimer
 from neon_mq_connector.utils.rabbit_utils import create_mq_callback
 from klat_connector.mq_klat_api import KlatAPIMQ
 from pika.exchange_type import ExchangeType
-from neon_data_models.models.api.mq.chatbots import ChatbotsMqRequest
+from neon_data_models.models.api.mq.chatbots import ChatbotsMqRequest, \
+    ChatbotsMqSubmindResponse
 
-from chatbot_core.utils.enum import ConversationState, BotTypes, CONVERSATION_STATE_ANNOUNCEMENTS
+from chatbot_core.utils.enum import ConversationState, BotTypes
 from chatbot_core.chatbot_abc import ChatBotABC
 from chatbot_core.version import __version__ as package_version
 
@@ -205,86 +206,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         # TODO: make it defaulting to True once all the related subminds are migrated (Kirill)
         return False
 
-    def get_chatbot_response(self, cid: str, message_data: dict, shout: str,
-                             message_sender: str, is_message_from_proctor: bool,
-                             conversation_state: ConversationState) -> dict:
-        """
-        Makes response based on incoming message data and its context
-        :param cid: current conversation id
-        :param message_data: message data received
-        :param shout: incoming shout data
-        :param message_sender: nick of message sender
-        :param is_message_from_proctor: is message sender a Proctor
-        :param conversation_state: state of the conversation
-
-        :returns response data as a dictionary, example:
-            {
-                "shout": "I vote for Wolfram",
-                "context": {"selected": "wolfram"},
-                "queue": "pat_user_message"
-            }
-        """
-        response = {'shout': '', 'context': {}, 'queue': ''}
-        self.log.debug(f'Received incoming shout from: {message_sender}. '
-                      f' state={conversation_state}|shout={shout}')
-        if self.contextual_api_supported:
-            context_kwargs = {'context': self._build_submind_request_context(message_data=message_data,
-                                                                             message_sender=message_sender,
-                                                                             is_message_from_proctor=is_message_from_proctor,
-                                                                             conversation_state=conversation_state)}
-        else:
-            context_kwargs = {}
-        if not is_message_from_proctor:
-            response['shout'] = self.ask_chatbot(user=message_sender,
-                                                 shout=shout,
-                                                 timestamp=str(message_data.get('timeCreated', int(time.time()))),
-                                                 **context_kwargs)
-        else:
-            response['to_discussion'] = '1'
-            response['conversation_state'] = conversation_state
-            message_sender = BotTypes.PROCTOR
-
-            prompt_id = message_data.get('prompt_id') or \
-                message_data.get('promptID') or ''
-            # self.set_conversation_state(cid, conversation_state)
-            if not prompt_id and conversation_state != ConversationState.IDLE:
-                prompt_id = self.current_conversations[cid]['prompt_history'][-1]
-                self.log.warning(f"Inferred prompt_id from history: {prompt_id}")
-
-                
-            if prompt_id:
-                current_prompt = self.current_conversations[cid]['prompts'][prompt_id]
-                # TODO: Include prompt history in context
-                if conversation_state == ConversationState.RESP:
-                    response['shout'] = self.ask_chatbot(user=message_sender,
-                                                         shout=shout,
-                                                         timestamp=str(message_data.get('timeCreated', int(time.time()))),
-                                                         **context_kwargs)
-                    current_prompt["proposal"] = response['shout']
-
-                elif conversation_state == ConversationState.DISC:
-                    options: dict = current_prompt.get('proposed_responses', {})
-                    # current_prompt['proposed_responses'] = options
-                    response['shout'] = self.ask_discusser(options, **context_kwargs)
-                elif conversation_state == ConversationState.VOTE:
-                    options: dict = current_prompt.get('proposed_responses', {})
-                    selected = self.ask_appraiser(options=options, **context_kwargs)
-                    response['shout'] = self.vote_response(selected)
-                    if 'abstain' in response['shout'].lower():
-                        selected = "abstain"
-                    response['context']['selected'] = selected
-                    # current_prompt['selected'] = selected
-                elif conversation_state == ConversationState.PICK:
-                    self.log.error("This should not be reached")
-                    return {}
-                elif conversation_state == ConversationState.WAIT:
-                    response['shout'] = 'I am ready for the next prompt'
-            else:
-                self.log.warning(f"No prompt id found in message data: "
-                                 f"{message_data}")
-            response['context']['prompt_id'] = message_data.get('prompt_id', '')
-        return response
-
     @staticmethod
     def _build_submind_request_context(message_data: dict,
                                        message_sender: str,
@@ -297,7 +218,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             'conversation_state': conversation_state.value,
         }
 
-    def handle_shout(self, message_data: dict, skip_callback: bool = False):
+    def handle_shout(self, message_data: dict):
         """
             Handles shout for bot. If receives response - emits message into "bot_response" queue
 
@@ -306,9 +227,15 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         """
         self.log.debug(f'Message data: {message_data}')
         message = ChatbotsMqRequest(**message_data)
+
+        # Remove suffix from username if it's really a `user_id`
+        if '-' in message.username:
+            message.username = message.username.rsplit('-', 1)[0]
+
         shout = message.message_text
         cid = message.cid
         prompt_id = message.prompt_id
+        context = {}  # TODO: Only used as a default for non-voting phases
 
         # Initialize prompt data structure if it doesn't exist
         if prompt_id and prompt_id not in self.prompt_to_cid:
@@ -317,6 +244,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.current_conversations[cid].setdefault("prompt_history", [])
             if prompt_id not in self.current_conversations[cid]['prompts']:
                 self.current_conversations[cid]['prompts'][prompt_id] = {
+                    "bot_name": self.nick,
                     "participating_subminds": [],
                     "proposed_responses": {},
                     "discussion": [{}],
@@ -368,6 +296,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
         # Handle any other message not related to conversation state handling
         conversation_state = self.get_conversation_state(cid)
+        if prompt_id:
+            current_prompt = \
+                self.current_conversations[cid]['prompts'][prompt_id]
 
         if not prompt_id:
             if is_message_from_proctor:
@@ -375,7 +306,20 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 return
             # Non-proctored conversation activity
             self.log.info(f"Non-proctored input: {message}")
-            # TODO: Get a response
+            response = self.ask_chatbot(
+                user=message_sender, shout=shout,
+                timestamp=str(round(message.time_created.timestamp)))
+            response = ChatbotsMqSubmindResponse(
+                user_id=self.uid,
+                username=self.nick,
+                message_text=response,
+                replied_message=message.message_id,
+                bot='1',
+                prompt_id=prompt_id,
+                source="chatbot",
+                to_discussion=True,
+                prompt_state=conversation_state,
+            )
         elif not is_message_from_proctor:
             # Submind response in proctored conversation
             self.log.debug(f"Handling non-proctor CCAI message. "
@@ -395,40 +339,49 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             except ValueError:
                 self.log.warning(f"Failed to parse winner from: {shout}")
             self.set_conversation_state(cid, ConversationState.IDLE)
-        # elif conversation_state == ConversationState.RESP:
-        #     # Proposal phase
-        # elif conversation_state == ConversationState.DISC:
-        #     # Discussion phase
-        # elif conversation_state == ConversationState.VOTE:
-        #     # Voting phase
-
-        elif shout:
-            # Proctor shout that wasn't already handled(?)
-            self.log.info(f"Responding to {message}")
-            if conversation_state == ConversationState.RESP:
-                self.current_conversations[cid]['prompts'][prompt_id]\
+        elif conversation_state == ConversationState.RESP:
+            # Proposal phase
+            self.current_conversations[cid]['prompts'][prompt_id]\
                     ["prompt"] = message.message_text
-            response = self.get_chatbot_response(cid=cid, message_data=message_data,
-                                                 shout=shout, message_sender=message_sender,
-                                                 is_message_from_proctor=is_message_from_proctor,
-                                                 conversation_state=conversation_state)
-            shout = response.get('shout', "")
-            if shout and not skip_callback:
-                self.log.info(f'Sending response: {response}')
-                prompt_id = response.get('context', {}).get('prompt_id')
-                self.send_shout(shout=shout,
-                                responded_message=message_data.get('messageID', ''),
-                                cid=cid,
-                                to_discussion=response.get('to_discussion', '0'),
-                                queue_name=response.get('queue', ""),
-                                context=response.get('context', None),
-                                is_announcement=response.get('is_announcement', False),
-                                prompt_id=prompt_id,
-                                **response.get('kwargs', {}))
-            else:
-                self.log.debug(
-                    f'{self.nick}: No response was sent as no data was '
-                    f'received from message data: {message_data}')
+            response = self.ask_chatbot(user=message_sender,
+                                        shout=shout,
+                                        timestamp=str(message.time_created.timestamp()))
+            # TODO: Remove `proposal` as it is per-cycle
+            current_prompt["proposal"] = response
+        elif conversation_state == ConversationState.DISC:
+            # Discussion phase
+            options: dict = current_prompt.get('proposed_responses', {})
+            current_prompt['proposed_responses'] = options
+            response = self.ask_discusser(options)
+        elif conversation_state == ConversationState.VOTE:
+            # Voting phase
+            options: dict = current_prompt.get('proposed_responses', {})
+            selected = self.ask_appraiser(options=options)
+            response = self.vote_response(selected)
+            if 'abstain' in response.lower():
+                selected = "abstain"
+            context = {'selected': selected}
+
+        if response:
+            self.log.info(f"Responding to {message}")
+            response = ChatbotsMqSubmindResponse(
+                user_id=self.uid,
+                username=self.nick,
+                message_text=response,
+                replied_message=message.message_id,
+                bot='1',
+                prompt_id=prompt_id,
+                source="chatbot",
+                to_discussion=True,
+                prompt_state=conversation_state,
+                context=context
+            )
+            self.send_shout(shout=response.message_text,
+                            responded_message=response.replied_message,
+                            cid=cid,
+                            to_discussion=response.to_discussion,
+                            is_announcement=response.is_announcement,
+                            prompt_id=response.prompt_id)
         else:
             self.log.warning(f'{self.nick}: Missing "shout" in received message data: {message_data}')
 

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -166,6 +166,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 body.get('receiver', None) == self.nick and \
                 self.nick != body.get('user', None):
             self._on_mentioned_user_message('', '', '', body)
+        else:
+            self.log.warning(f"Ignoring message: {body}")
 
     def handle_incoming_shout(self, message_data: dict):
         """

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -318,18 +318,26 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.set_conversation_state(cid, message_data['conversation_state'])
             self.log.info(f"Conversation state from message data: {conversation_state}")
         elif is_message_from_proctor:
+            changed = False
             # Proctor cotrol message
             # TODO: Better check here
             if "accepting responses" in shout.lower():
+                changed = True
                 self.set_conversation_state(cid, ConversationState.RESP)
             elif "discussing responses" in shout.lower():
+                changed = True
                 self.set_conversation_state(cid, ConversationState.DISC)
             elif "voting for candidate responses" in shout.lower():
+                changed = True
                 self.set_conversation_state(cid, ConversationState.VOTE)
-            elif "the selected response is from" in shout.lower():
+            elif "selecting a winner among participants" in shout.lower():
+                changed = True
                 self.set_conversation_state(cid, ConversationState.PICK)
-            self.log.info(f"Conversation state from proctor shout: "
-                          f"{self.get_conversation_state(cid)}")
+            if changed:
+                self.log.info(f"Conversation state set from proctor shout: "
+                            f"{self.get_conversation_state(cid)}")
+            # Proctor messages without a state context should be ignored
+            return
 
         conversation_state = self.get_conversation_state(cid)
         prompt_id = message_data.get("promptID") or message_data.get('prompt_id')

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -226,7 +226,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.current_conversations.setdefault(cid, {})
             self.current_conversations[cid].setdefault("prompts", {})
             self.current_conversations[cid].setdefault("prompt_history", [])
-            prompt_id = message_data.get('prompt_id', '')
+            prompt_id = message_data.get('prompt_id') or \
+                message_data.get('promptID') or ''
             self.set_conversation_state(cid, conversation_state)
             if not prompt_id and conversation_state != ConversationState.IDLE:
                 prompt_id = self.current_conversations[cid]['prompt_history'][-1]
@@ -270,9 +271,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     current_prompt['selected'] = selected
                 elif conversation_state == ConversationState.PICK:
                     preamble, response = shout.split(":", 1)
-                    current_prompt["response"] = response.strip()
+                    current_prompt["response"] = response.strip().strip('"')
                     current_prompt["winner"] = preamble.split(" ")[-1]
                     self.log.info(f"Completed prompt: {current_prompt}")
+                    return {}
                 elif conversation_state == ConversationState.WAIT:
                     response['shout'] = 'I am ready for the next prompt'
             else:
@@ -317,7 +319,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             conversation_state = ConversationState.PICK
 
 
-        if prompt_id := message_data.get("promptID") is not None and \
+        if prompt_id := (message_data.get("promptID") or
+                         message_data.get('prompt_id')) is not None and \
                 not is_message_from_proctor:
             self.log.debug("Handling non-proctor CCAI message")
             if conversation_state == ConversationState.RESP:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -272,6 +272,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     self.log.info(f"Completed prompt: {current_prompt}")
                 elif conversation_state == ConversationState.WAIT:
                     response['shout'] = 'I am ready for the next prompt'
+            else:
+                self.log.warning(f"No prompt id found in message data: "
+                                 f"{message_data}")
             response['context']['prompt_id'] = message_data.get('prompt_id', '')
         return response
 

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -327,8 +327,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         message_sender = message.username
         is_message_from_proctor = self._user_is_proctor(message_sender)
 
+        # Handle control messages that indicate a change in conversation phase
+        changed = False
         if is_message_from_proctor:
-            changed = False
             # Proctor cotrol message
             # TODO: Better check here
             if "accepting responses" in shout.lower():
@@ -343,20 +344,24 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             elif "selecting a winner among participants" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.PICK)
-                return
             if changed:
-                self.log.debug(f"Conversation state set from proctor shout: "
+                self.log.info(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")
-        elif message.prompt_state and \
-                message.prompt_state != ConversationState.IDLE:
-            old_state = self.get_conversation_state(cid)
-            self.set_conversation_state(cid, message.prompt_state)
-            self.log.debug(f"Conversation state from message data: "
-                          f"{self.get_conversation_state(cid)}")
-            if self.get_conversation_state(cid) != old_state:
-                self.log.warning(f"Conversation state changed by Proctor "
-                                 f"message to {message.prompt_state}")
+            if not changed and message.prompt_state \
+                    and message.prompt_state != ConversationState.IDLE:
+                old_state = self.get_conversation_state(cid)
+                self.set_conversation_state(cid, message.prompt_state)
+                self.log.debug(f"Conversation state from message data: "
+                            f"{self.get_conversation_state(cid)}")
+                if self.get_conversation_state(cid) != old_state:
+                    self.log.warning(f"Conversation state changed by Proctor "
+                                    f"message to {message.prompt_state}")
+                    changed = True
+        if changed:
+            self.log.info(f"State changed by message: {message}")
+            return
 
+        # Handle any other message not related to conversation state handling
         conversation_state = self.get_conversation_state(cid)
         prompt_id = message.prompt_id
 
@@ -365,7 +370,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.info(f"Non-proctored input: {message}")
         elif not is_message_from_proctor:
             # Submind response in proctored conversation
-            self.log.debug(f"Handling non-proctor CCAI message. "
+            self.log.info(f"Handling non-proctor CCAI message. "
                            f"state={conversation_state}")
             if conversation_state == ConversationState.RESP:
                 self.on_proposed_response(prompt_id, shout, message_sender)
@@ -390,7 +395,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         #     # Voting phase
 
         elif shout:
-            self.log.info(f"Responding to {shout}")
+            # Proctor shout that wasn't already handled(?)
+            self.log.info(f"Responding to {shout} from {message_sender}")
             response = self.get_chatbot_response(cid=cid, message_data=message_data,
                                                  shout=shout, message_sender=message_sender,
                                                  is_message_from_proctor=is_message_from_proctor,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -306,8 +306,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         self.log.debug(f'Message data: {message_data}')
         shout = message_data.get('shout') or message_data.get('messageText', '')
         cid = message_data.get('cid', '')
-        # TODO: Refactor to track this internally instead of from message context
-        conversation_state = ConversationState(message_data.get('conversation_state', 0))
+        # Refactored to track this internally instead of from message context
+        # conversation_state = ConversationState(message_data.get('conversation_state', 0))
 
         message_sender = message_data.get('nick') or \
             message_data.get('userDisplayName', 'anonymous')
@@ -327,9 +327,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.info(f"Proctor set state to: "
                             f"{self.get_conversation_state(cid)}")
 
+            conversation_state = self.get_conversation_state(cid)
+
         prompt_id = message_data.get("promptID") or message_data.get('prompt_id')
         if prompt_id and not is_message_from_proctor:
-            conversation_state = self.get_conversation_state(cid)
             self.log.info(f"Handling non-proctor CCAI message. state={conversation_state}")
             if conversation_state == ConversationState.RESP:
                 self.on_proposed_response(prompt_id, shout, message_sender)

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -318,8 +318,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         prompt_id = message.prompt_id
 
         # Initialize prompt data structure if it doesn't exist
-        if prompt_id and \
-                self.get_conversation_state(cid) == ConversationState.IDLE:
+        if prompt_id and prompt_id not in self.prompt_to_cid:
             self.current_conversations.setdefault(cid, {})
             self.current_conversations[cid].setdefault("prompts", {})
             self.current_conversations[cid].setdefault("prompt_history", [])

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -27,8 +27,9 @@ from klat_connector.mq_klat_api import KlatAPIMQ
 from pika.exchange_type import ExchangeType
 from neon_data_models.models.api.mq.chatbots import ChatbotsMqRequest, \
     ChatbotsMqSubmindResponse
+from neon_data_models.enum import CcaiState as ConversationState
 
-from chatbot_core.utils.enum import ConversationState, BotTypes
+from chatbot_core.utils.enum import BotTypes
 from chatbot_core.chatbot_abc import ChatBotABC
 from chatbot_core.version import __version__ as package_version
 
@@ -177,8 +178,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 self._user_is_proctor(message.username):
             self.log.debug(f"Ignoring proctor message: {body=}")
             return
-        if self._user_is_proctor(message.username):
-            self.log.info(f"Received proctor message: {body=}")
         self.handle_incoming_shout(message.model_dump())
 
     @create_mq_callback()
@@ -341,6 +340,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             try:
                 preamble, choice = shout.split(":", 1)
                 winner = preamble.split(" ")[-1]
+                choice = choice.strip().strip('"')
                 self.on_selection(prompt_id, winner, choice)
             except ValueError:
                 self.log.warning(f"Failed to parse winner from: {shout}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -228,6 +228,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.current_conversations[cid].setdefault("prompt_history", [])
             prompt_id = message_data.get('prompt_id', '')
             self.set_conversation_state(cid, conversation_state)
+            if not prompt_id and conversation_state != ConversationState.IDLE:
+                prompt_id = self.current_conversations[cid]['prompt_history'][-1]
+                self.log.info(f"Inferred prompt_id from history: {prompt_id}")
             if prompt_id:
                 # Initialize prompt data structure if it doesn't exist
                 if prompt_id not in self.current_conversations[cid]['prompts']:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -329,10 +329,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.warning(f"Proctor specified idle state, but is a pick")
             conversation_state = self.get_conversation_state(cid)
 
-
-        if prompt_id := (message_data.get("promptID") or
-                         message_data.get('prompt_id')) is not None and \
-                not is_message_from_proctor:
+        prompt_id = message_data.get("promptID") or message_data.get('prompt_id')
+        if prompt_id and not is_message_from_proctor:
             conversation_state = self.get_conversation_state(cid)
             self.log.info(f"Handling non-proctor CCAI message. state={conversation_state}")
             if conversation_state == ConversationState.RESP:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -172,9 +172,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.debug(f"{body}")
             return
         if self.supports_raw_conversation and \
-                self._user_is_proctor(message.username) and \
-                message.prompt_state is not None:
-            self.log.info(f"Ignoring proctor state message: {message}")
+                message.requested_participants and \
+                self._user_is_proctor(message.username):
+            self.log.info(f"Ignoring targeted message: {message.message_text}")
             return
         self.handle_incoming_shout(message.model_dump())
 

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -173,7 +173,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.debug(f"{body}")
             return
         if self.supports_raw_conversation and \
-                message.requested_participants and \
+                message.requested_participants is not None and \
                 self._user_is_proctor(message.username):
             self.log.info(f"Ignoring targeted message: {message.message_text}")
             return
@@ -294,7 +294,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     changed = True
         if changed:
             self.log.info(f"State changed to: "
-                          f"{self.get_conversation_state(cid)}")
+                          f"{self.get_conversation_state(cid).name}")
             return
 
         # Handle any other message not related to conversation state handling

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -47,7 +47,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         # Mapping of CID to context including `state` and `prompts`
         self.current_conversations: Dict[str, dict] = dict()
         # Mapping of prompt_id to associated CID
-        self.prompt_to_cid = Dict[str, str] = dict()
+        self.prompt_to_cid: Dict[str, str] = dict()
         self.on_server = True
         self.default_response_queue = 'shout'
         self.shout_thread = RepeatingTimer(function=self._handle_next_shout,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -260,7 +260,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                                                          shout=shout,
                                                          timestamp=str(message_data.get('timeCreated', int(time.time()))),
                                                          **context_kwargs)
-                    current_prompt["prompt"] = message_data.get('shout', '')
                     current_prompt["proposal"] = response['shout']
 
                 elif conversation_state == ConversationState.DISC:
@@ -318,6 +317,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.current_conversations[cid].setdefault("prompt_history", [])
             if prompt_id not in self.current_conversations[cid]['prompts']:
                 self.current_conversations[cid]['prompts'][prompt_id] = {
+                    "prompt": message.message_text,
                     "participating_subminds": [],
                     "proposed_responses": {},
                     "discussion": [{}],
@@ -325,7 +325,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 }
             self.current_conversations[cid]['prompt_history'].append(prompt_id)
             self.prompt_to_cid[prompt_id] = cid
-            self.log.info(f"Starting new prompt: {prompt_id}")
+            self.log.info(
+                f"Starting new prompt: {prompt_id}: {message.message_text}")
 
 
         message_sender = message.username

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -155,6 +155,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         """
             MQ handler for requesting message for current bot
         """
+        # TODO: Backwards-compat. data key handling
+        if "shout" in body:
+            body.setdefault("message_text", body.get('shout', ''))
+
         message = ChatbotsMqRequest(**body)
         if body.get('omit_reply'):
             self.log.debug(f"Explicitly requested no response: messageID="
@@ -172,7 +176,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 message.conversation_state is not None:
             self.log.info(f"Ignoring proctor state message: {message}")
             return
-        self.handle_incoming_shout(body)
+        self.handle_incoming_shout(message.model_dump())
 
     @create_mq_callback()
     def _on_user_message(self, body: dict):
@@ -321,9 +325,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             :param skip_callback: to skip callback after handling shout (default to False)
         """
         self.log.debug(f'Message data: {message_data}')
-        # TODO: Backwards-compat. data key handling
-        if "shout" in message_data:
-            message_data.setdefault("message_text", message_data.get('shout', ''))
         message = ChatbotsMqRequest(**message_data)
         shout = message.message_text
         cid = message.cid

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -49,6 +49,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         # Mapping of prompt_id to associated CID
         self.prompt_to_cid: Dict[str, str] = dict()
         self.on_server = True
+        self.supports_raw_conversation = True
         self.default_response_queue = 'shout'
         self.shout_thread = RepeatingTimer(function=self._handle_next_shout,
                                            interval=kwargs.get('shout_thread_interval', 10))
@@ -381,9 +382,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         self.send_shout(shout='chatbot state',
                         context={
                             'service_name': self.service_name,
-                            'version': os.environ.get('SERVICE_VERSION', package_version),
+                            'version': os.environ.get('SERVICE_VERSION', 
+                                                      package_version),
                             'bot_type': self.bot_type,
-                            'supports_raw_conversation': True,  # TODO: infer from version OR make this optional per-submind
+                            'supports_raw_conversation': self.supports_raw_conversation,
                             'cids': list(self.current_conversations),
                         },
                         exchange='connection')

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -345,7 +345,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 changed = True
                 self.set_conversation_state(cid, ConversationState.PICK)
             if changed:
-                self.log.info(f"Conversation state set from proctor shout: "
+                self.log.debug(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")
             if not changed and message.prompt_state \
                     and message.prompt_state != ConversationState.IDLE:
@@ -358,7 +358,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                                     f"message to {message.prompt_state}")
                     changed = True
         if changed:
-            self.log.info(f"State changed by message: {message}")
+            self.log.info(f"State changed to: "
+                          f"{self.get_conversation_state(cid)}")
             return
 
         # Handle any other message not related to conversation state handling
@@ -366,12 +367,16 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         prompt_id = message.prompt_id
 
         if not prompt_id:
+            if is_message_from_proctor:
+                # Proctor control message
+                return
             # Non-proctored conversation activity
             self.log.info(f"Non-proctored input: {message}")
+            # TODO: Get a response
         elif not is_message_from_proctor:
             # Submind response in proctored conversation
-            self.log.info(f"Handling non-proctor CCAI message. "
-                           f"state={conversation_state}")
+            self.log.debug(f"Handling non-proctor CCAI message. "
+                           f"state={conversation_state.name}")
             if conversation_state == ConversationState.RESP:
                 self.on_proposed_response(prompt_id, shout, message_sender)
             elif conversation_state == ConversationState.DISC:
@@ -396,7 +401,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
         elif shout:
             # Proctor shout that wasn't already handled(?)
-            self.log.info(f"Responding to {shout} from {message_sender}")
+            self.log.info(f"Responding to {message}")
             response = self.get_chatbot_response(cid=cid, message_data=message_data,
                                                  shout=shout, message_sender=message_sender,
                                                  is_message_from_proctor=is_message_from_proctor,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -177,7 +177,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 self._user_is_proctor(message.username):
             self.log.info(f"Ignoring proctor message: {message.message_text}")
             return
-        if self._user_is_proctor(message.usewrname):
+        if self._user_is_proctor(message.username):
             self.log.info(f"Received proctor message: {message.message_text}")
         self.handle_incoming_shout(message.model_dump())
 

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -295,11 +295,12 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         shout = message_data.get('shout') or message_data.get('messageText', '')
         cid = message_data.get('cid', '')
         conversation_state = ConversationState(message_data.get('conversation_state', 0))
-        message_sender = message_data.get('nick', 'anonymous')
+        message_sender = message_data.get('nick') or \
+            message_data.get('userDisplayName', 'anonymous')
         is_message_from_proctor = self._user_is_proctor(message_sender)
         if prompt_id := message_data.get("promptID") is not None and \
                 not is_message_from_proctor:
-            self.log.info("Handling non-proctor CCAI message")  # TODO: log.debug
+            self.log.debug("Handling non-proctor CCAI message")
             if conversation_state == ConversationState.RESP:
                 self.on_proposed_response(prompt_id, shout, message_sender)
             elif conversation_state == ConversationState.DISC:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -320,6 +320,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         # Initialize prompt data structure if it doesn't exist
         if prompt_id and \
                 self.get_conversation_state(cid) == ConversationState.IDLE:
+            self.current_conversations.setdefault(cid, {})
+            self.current_conversations[cid].setdefault("prompts", {})
+            self.current_conversations[cid].setdefault("prompt_history", [])
             if prompt_id not in self.current_conversations[cid]['prompts']:
                 self.current_conversations[cid]['prompts'][prompt_id] = {
                     "proposed_responses": {},

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -370,8 +370,12 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             elif conversation_state == ConversationState.VOTE:
                 self.on_vote(prompt_id, shout, message_sender)
         elif conversation_state == ConversationState.PICK:
-                preamble, choice = shout.split(":", 1)
-                winner = preamble.split(" ")[-1]
+                try:
+                    preamble, choice = shout.split(":", 1)
+                    winner = preamble.split(" ")[-1]
+                except ValueError:
+                    self.log.warning(f"Failed to parse winner from: {shout}")
+                    return
                 self.on_selection(prompt_id, winner, choice)
         elif shout:
             response = self.get_chatbot_response(cid=cid, message_data=message_data,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -327,15 +327,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         message_sender = message.username
         is_message_from_proctor = self._user_is_proctor(message_sender)
 
-        if message.prompt_state:
-            old_state = self.get_conversation_state(cid)
-            self.set_conversation_state(cid, message.prompt_state)
-            self.log.debug(f"Conversation state from message data: "
-                          f"{self.get_conversation_state(cid)}")
-            if self.get_conversation_state(cid) != old_state:
-                self.log.warning(
-                    f"Conversation state changed by Proctor message")
-        elif is_message_from_proctor:
+        if is_message_from_proctor:
             changed = False
             # Proctor cotrol message
             # TODO: Better check here
@@ -351,11 +343,18 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             elif "selecting a winner among participants" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.PICK)
+                return
             if changed:
                 self.log.debug(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")
-                # Proctor message has no other purpose
-                return
+        elif message.prompt_state:
+            old_state = self.get_conversation_state(cid)
+            self.set_conversation_state(cid, message.prompt_state)
+            self.log.debug(f"Conversation state from message data: "
+                          f"{self.get_conversation_state(cid)}")
+            if self.get_conversation_state(cid) != old_state:
+                self.log.warning(
+                    f"Conversation state changed by Proctor message")
 
         conversation_state = self.get_conversation_state(cid)
         prompt_id = message.prompt_id

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -265,9 +265,12 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                         selected = "abstain"
                     response['context']['selected'] = selected
                     current_prompt['selected'] = selected
-                elif conversation_state == ConversationState.WAIT:
-                    current_prompt["response"] = shout
+                elif conversation_state == ConversationState.PICK:
+                    preamble, response = shout.split(":", 1)
+                    current_prompt["response"] = response.strip()
+                    current_prompt["winner"] = preamble.split(" ")[-1]
                     self.log.info(f"Completed prompt: {current_prompt}")
+                elif conversation_state == ConversationState.WAIT:
                     response['shout'] = 'I am ready for the next prompt'
             response['context']['prompt_id'] = message_data.get('prompt_id', '')
         return response
@@ -295,9 +298,19 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         shout = message_data.get('shout') or message_data.get('messageText', '')
         cid = message_data.get('cid', '')
         conversation_state = ConversationState(message_data.get('conversation_state', 0))
+
         message_sender = message_data.get('nick') or \
             message_data.get('userDisplayName', 'anonymous')
         is_message_from_proctor = self._user_is_proctor(message_sender)
+
+        # TODO: Patching Proctor message handling
+        if conversation_state == ConversationState.IDLE and \
+            is_message_from_proctor and \
+                shout.startswith("The selected resposne"):
+            self.log.warning(f"Proctor specified idle state, but is a pick")
+            conversation_state = ConversationState.PICK
+
+
         if prompt_id := message_data.get("promptID") is not None and \
                 not is_message_from_proctor:
             self.log.debug("Handling non-proctor CCAI message")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -155,16 +155,22 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         """
             MQ handler for requesting message for current bot
         """
+        message = ChatbotsMqRequest(**body)
         if body.get('omit_reply'):
             self.log.debug(f"Explicitly requested no response: messageID="
                            f"{body.get('messageID')}")
             return
-        if body.get('cid') not in list(self.current_conversations):
+        if message.cid not in list(self.current_conversations):
             self.log.debug(f"Ignoring message "
                           f"(messageID={body.get('messageID')}) outside of "
                           f"current conversations "
                           f"({self.current_conversations})")
             self.log.debug(f"{body}")
+            return
+        if self.supports_raw_conversation and \
+                self._user_is_proctor(message.username) and \
+                message.conversation_state is not None:
+            self.log.info(f"Ignoring proctor state message: {message}")
             return
         self.handle_incoming_shout(body)
 
@@ -304,7 +310,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             'prompt_id': message_data.get('prompt_id', ''),
             'message_sender': message_sender,
             'is_message_from_proctor': is_message_from_proctor,
-            'conversation_state': conversation_state,
+            'conversation_state': conversation_state.value,
         }
 
     def handle_shout(self, message_data: dict, skip_callback: bool = False):

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -238,8 +238,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         prompt_id = message.prompt_id
         response = None
 
-        if message.requested_participants:
-            self.log.info(f"Got requested participants: {message}")
+        if "are selected for current prompt" in shout:
+            self.log.info(f"Proctor selected next subminds: {message}")
 
         # Initialize prompt data structure if it doesn't exist
         if prompt_id and prompt_id not in self.prompt_to_cid:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -368,7 +368,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             context = {'selected': selected}
 
         if response:
-            self.log.info(f"Responding to {message}")
+            self.log.info(f"Responding to {message.message_text}")
             response = ChatbotsMqSubmindResponse(
                 cid=message.cid,
                 user_id=self.uid,
@@ -388,6 +388,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                             to_discussion=response.to_discussion,
                             is_announcement=response.is_announcement,
                             prompt_id=response.prompt_id)
+            self.log.info(f"Sent response to {response.cid}: "
+                          f"{response.message_text} ")
         else:
             self.log.warning(
                 f'No response generated with state={conversation_state.name} '

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -306,7 +306,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         # TODO: Patching Proctor message handling
         if conversation_state == ConversationState.IDLE and \
             is_message_from_proctor and \
-                shout.startswith("The selected resposne"):
+                shout.startswith("The selected response"):
             self.log.warning(f"Proctor specified idle state, but is a pick")
             conversation_state = ConversationState.PICK
 

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -372,7 +372,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             response = ChatbotsMqSubmindResponse(
                 cid=message.cid,
                 user_id=self.uid,
-                username=self.nick,
+                username=self.service_name,
                 message_text=response,
                 replied_message=message.message_id,
                 bot='1',
@@ -384,10 +384,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             )
             self.send_shout(shout=response.message_text,
                             responded_message=response.replied_message,
-                            cid=cid,
-                            to_discussion=response.to_discussion,
-                            is_announcement=response.is_announcement,
-                            prompt_id=response.prompt_id)
+                            **response.model_dump())
             self.log.info(f"Sent response to {response.cid}: "
                           f"{response.message_text} ")
         else:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -105,7 +105,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         self.current_conversations.setdefault(cid, {})['state'] = state
         new_state = self.current_conversations.setdefault(cid, {}).get(
             "state", ConversationState.IDLE)
-        self.log.debug(f'State become: {new_state}')
+        self.log.debug(f'State became: {new_state}')
 
     def _setup_listeners(self):
         KlatAPIMQ._setup_listeners(self)
@@ -262,28 +262,21 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                                                          **context_kwargs)
                     current_prompt["prompt"] = message_data.get('shout', '')
                     current_prompt["proposal"] = response['shout']
-                    current_prompt["participating_subminds"] = message_data.get(
-                        'participating_subminds', [])
+
                 elif conversation_state == ConversationState.DISC:
-                    current_prompt.setdefault("discussion", [{}])
-                    # TODO: Get `proposed_responses` from internal reference
-                    options: dict = message_data.get('proposed_responses', {})
-                    current_prompt['proposed_responses'] = options
+                    options: dict = current_prompt.get('proposed_responses', {})
+                    # current_prompt['proposed_responses'] = options
                     response['shout'] = self.ask_discusser(options, **context_kwargs)
                 elif conversation_state == ConversationState.VOTE:
-                    # TODO: Get `proposed_responses` from internal reference
-                    options = message_data.get('proposed_responses', {})
+                    options: dict = current_prompt.get('proposed_responses', {})
                     selected = self.ask_appraiser(options=options, **context_kwargs)
                     response['shout'] = self.vote_response(selected)
                     if 'abstain' in response['shout'].lower():
                         selected = "abstain"
                     response['context']['selected'] = selected
-                    current_prompt['selected'] = selected
+                    # current_prompt['selected'] = selected
                 elif conversation_state == ConversationState.PICK:
-                    preamble, choice = shout.split(":", 1)
-                    current_prompt["response"] = choice.strip().strip('"')
-                    current_prompt["winner"] = preamble.split(" ")[-1]
-                    self.log.info(f"Completed prompt: {current_prompt}")
+                    self.log.error("This should not be reached")
                     return {}
                 elif conversation_state == ConversationState.WAIT:
                     response['shout'] = 'I am ready for the next prompt'
@@ -325,6 +318,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.current_conversations[cid].setdefault("prompt_history", [])
             if prompt_id not in self.current_conversations[cid]['prompts']:
                 self.current_conversations[cid]['prompts'][prompt_id] = {
+                    "participating_subminds": [],
                     "proposed_responses": {},
                     "discussion": [{}],
                     "votes": {}
@@ -492,6 +486,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         if not prompt_data:
             self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
             return
+        if user not in prompt_data['participating_subminds']:
+            prompt_data['participating_subminds'].append(user)
         prompt_data['proposed_responses'][user] = response
         self.log.debug(f"Received proposed response from {user}: {response}")
 

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -173,7 +173,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             return
         if self.supports_raw_conversation and \
                 self._user_is_proctor(message.username) and \
-                message.conversation_state is not None:
+                message.prompt_state is not None:
             self.log.info(f"Ignoring proctor state message: {message}")
             return
         self.handle_incoming_shout(message.model_dump())

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -327,9 +327,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.info(f"Proctor set state to: "
                             f"{self.get_conversation_state(cid)}")
 
-            conversation_state = self.get_conversation_state(cid)
-
+        conversation_state = self.get_conversation_state(cid)
         prompt_id = message_data.get("promptID") or message_data.get('prompt_id')
+        
         if prompt_id and not is_message_from_proctor:
             self.log.info(f"Handling non-proctor CCAI message. state={conversation_state}")
             if conversation_state == ConversationState.RESP:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -270,7 +270,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             if "accepting responses" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.RESP)
-                subminds = message_data.get("participating_subminds")
+                subminds = message_data.get("participating_subminds", [])
                 self.current_conversations[cid]['prompts'][prompt_id]\
                     ["participating_subminds"] = subminds
                 self.log.info(f"Participating subminds set to: {subminds}")
@@ -296,6 +296,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     self.log.warning(f"Conversation state changed by Proctor "
                                     f"message to {message.prompt_state}")
                     changed = True
+            if prompt_id and "participating_subminds" in message_data:
+                self.log.info(f"Got participants from: {message_data}")
         if changed:
             self.log.info(f"State changed to: "
                           f"{self.get_conversation_state(cid).name}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -270,6 +270,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             if "accepting responses" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.RESP)
+                subminds = message_data.get("participating_subminds")
+                self.current_conversations[cid]['prompts'][prompt_id]\
+                    ["participating_subminds"] = subminds
+                self.log.info(f"Participating subminds set to: {subminds}")
             elif "discussing responses" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.DISC)
@@ -306,6 +310,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         if not prompt_id:
             if is_message_from_proctor:
                 # Proctor control message
+                # TODO: Can we re-define the proctor to always specify a prompt_id?
                 return
             # Non-proctored conversation activity
             self.log.info(f"Non-proctored input: {message}")
@@ -447,7 +452,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
             return
         if user not in prompt_data['participating_subminds']:
-            prompt_data['participating_subminds'].append(user)
+            self.log.warning(f"{user} is not participating in this prompt")
+            return
         prompt_data["cycles"][-1]['proposed_responses'][user] = response
         self.log.debug(f"Received proposed response from {user}: {response}")
 
@@ -459,6 +465,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             .get('prompts', {}).get(prompt_id, {})
         if not prompt_data:
             self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
+            return
+        if user not in prompt_data['participating_subminds']:
+            self.log.warning(f"{user} is not participating in this prompt")
             return
         if user in prompt_data["cycles"][-1]['discussion'][-1]:
             # Users can only send one discussion message per round. Use this
@@ -475,6 +484,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             .get('prompts', {}).get(prompt_id, {})
         if not prompt_data:
             self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
+            return
+        if voter not in prompt_data['participating_subminds']:
+            self.log.warning(f"{voter} is not participating in this prompt")
             return
         prompt_data["cycles"][-1]['votes'][voter] = selected
         self.log.debug(f"Received vote from {voter}: {selected}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -25,6 +25,7 @@ from neon_mq_connector.utils import RepeatingTimer
 from neon_mq_connector.utils.rabbit_utils import create_mq_callback
 from klat_connector.mq_klat_api import KlatAPIMQ
 from pika.exchange_type import ExchangeType
+from neon_data_models.models.api.mq.chatbots import ChatbotsMqRequest
 
 from chatbot_core.utils.enum import ConversationState, BotTypes, CONVERSATION_STATE_ANNOUNCEMENTS
 from chatbot_core.chatbot_abc import ChatBotABC
@@ -83,12 +84,21 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.current_conversations[new_cid] = body
             self.set_conversation_state(new_cid, ConversationState.IDLE)
             if announce_invitation:
-                self.send_announcement(f'{self.nick.split("-")[0]} joined', new_cid)
+                self.send_announcement(f'{self.nick.split("-")[0]} joined',
+                                       new_cid)
 
-    def get_conversation_state(self, cid) -> ConversationState:
-        return self.current_conversations.get(cid, {}).get('state', ConversationState.IDLE)
+    def get_conversation_state(self, cid: str) -> ConversationState:
+        """
+        Get the state of a conversation
+        """
+        return self.current_conversations.get(cid,
+                                              {}).get('state', 
+                                                      ConversationState.IDLE)
 
-    def set_conversation_state(self, cid, state):
+    def set_conversation_state(self, cid: str, state: ConversationState):
+        """
+        Set/update the state of a conversation
+        """
         old_state = self.current_conversations.setdefault(cid, {}).get(
             "state", ConversationState.IDLE)
         self.log.debug(f'State was: {old_state}')
@@ -305,20 +315,23 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             :param skip_callback: to skip callback after handling shout (default to False)
         """
         self.log.debug(f'Message data: {message_data}')
-        shout = message_data.get('shout') or message_data.get('messageText', '')
-        cid = message_data.get('cid', '')
+        message = ChatbotsMqRequest(**message_data)
+        shout = message.message_text
+        cid = message.cid
         # Refactored to track this internally instead of from message context
         # conversation_state = ConversationState(message_data.get('conversation_state', 0))
 
-        message_sender = message_data.get('nick') or \
-            message_data.get('userDisplayName', 'anonymous')
+        message_sender = message.username
         is_message_from_proctor = self._user_is_proctor(message_sender)
 
-        # TODO: Refactor to not rely on `conversation_state` context proctor ctx
-        if "conversation_state" in message_data:
-            self.set_conversation_state(cid, message_data['conversation_state'])
+        if message.prompt_state:
+            old_state = self.get_conversation_state(cid)
+            self.set_conversation_state(cid, message.prompt_state)
             self.log.debug(f"Conversation state from message data: "
                           f"{self.get_conversation_state(cid)}")
+            if self.get_conversation_state(cid) != old_state:
+                self.log.warning(
+                    f"Conversation state changed by Proctor message")
         elif is_message_from_proctor:
             changed = False
             # Proctor cotrol message
@@ -342,17 +355,21 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 return
 
         conversation_state = self.get_conversation_state(cid)
-        prompt_id = message_data.get("promptID") or message_data.get('prompt_id')
+        prompt_id = message.prompt_id
 
         if prompt_id and not is_message_from_proctor:
-            self.log.debug(f"Handling non-proctor CCAI message. state={conversation_state}")
+            self.log.debug(f"Handling non-proctor CCAI message. "
+                           f"state={conversation_state}")
             if conversation_state == ConversationState.RESP:
                 self.on_proposed_response(prompt_id, shout, message_sender)
             elif conversation_state == ConversationState.DISC:
                 self.on_discussion(message_sender, shout, prompt_id)
             elif conversation_state == ConversationState.VOTE:
                 self.on_vote(prompt_id, shout, message_sender)
-
+        elif conversation_state == ConversationState.PICK:
+                preamble, choice = shout.split(":", 1)
+                winner = preamble.split(" ")[-1]
+                self.on_selection(prompt_id, winner, choice)
         elif shout:
             response = self.get_chatbot_response(cid=cid, message_data=message_data,
                                                  shout=shout, message_sender=message_sender,
@@ -466,10 +483,17 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         prompt_data['votes'][voter] = selected
         self.log.debug(f"Received vote from {voter}: {selected}")
 
-    # TODO: Implement below methods in place of handling in `get_chatbot_response`
-    def on_selection(self, prompt: str, user: str, response: str):
-        pass
+    def on_selection(self, prompt_id: str, user: str, response: str):
+        if prompt_id not in self.prompt_to_cid:
+            self.log.warning(f"Unknown prompt id: {prompt_id}")
+            return
+        cid = self.prompt_to_cid[prompt_id]
+        current_prompt = self.current_conversations[cid]['prompts'][prompt_id]
+        current_prompt["response"] = response
+        current_prompt["winner"] = user
+        self.log.info(f"Completed prompt: {current_prompt}")
 
+    # TODO: Implement below methods in place of handling in `get_chatbot_response`
     def on_ready_for_next(self, user: str):
         pass
 

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -240,6 +240,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
         if "are selected for current prompt" in shout:
             self.log.info(f"Proctor selected next subminds: {message}")
+            message.prompt_state = ConversationState.IDLE
 
         # Initialize prompt data structure if it doesn't exist
         if prompt_id and prompt_id not in self.prompt_to_cid:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -175,10 +175,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         if self.supports_raw_conversation and \
                 message.prompt_state is not None and \
                 self._user_is_proctor(message.username):
-            self.log.info(f"Ignoring proctor message: {message.message_text}")
+            self.log.info(f"Ignoring proctor message: {body=}")
             return
         if self._user_is_proctor(message.username):
-            self.log.info(f"Received proctor message: {message.message_text}")
+            self.log.info(f"Received proctor message: {body=}")
         self.handle_incoming_shout(message.model_dump())
 
     @create_mq_callback()

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -315,6 +315,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             :param skip_callback: to skip callback after handling shout (default to False)
         """
         self.log.debug(f'Message data: {message_data}')
+        # TODO: Backwards-compat. data key handling
+        if "shout" in message_data:
+            message.setdefault("message_text", message_data.get('shout', ''))
         message = ChatbotsMqRequest(**message_data)
         shout = message.message_text
         cid = message.cid

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -198,10 +198,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             Handles an incoming shout into the current conversation
             :param message_data: data of incoming message
         """
-        if message_data.get("prompt_state") is not None and \
-            self.supports_raw_conversation:
-            # Raw conversation does not need the extra proctor messages
-            return
         self.shout_queue.put(message_data)
 
     @property
@@ -392,7 +388,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                             is_announcement=response.is_announcement,
                             prompt_id=response.prompt_id)
         else:
-            self.log.warning(f'{self.nick}: Missing "shout" in received message data: {message_data}')
+            self.log.warning(f'No response generated for message data: {message_data}')
 
     def _send_state(self):
         self.send_shout(shout='chatbot state',

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -317,7 +317,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         self.log.debug(f'Message data: {message_data}')
         # TODO: Backwards-compat. data key handling
         if "shout" in message_data:
-            message.setdefault("message_text", message_data.get('shout', ''))
+            message_data.setdefault("message_text", message_data.get('shout', ''))
         message = ChatbotsMqRequest(**message_data)
         shout = message.message_text
         cid = message.cid

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -172,8 +172,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                           f"({self.current_conversations})")
             self.log.debug(f"{body}")
             return
-        if self.supports_raw_conversation and \
-                message.prompt_state is not None and \
+        # `routing_key` check is a hack to exclude old messages from Proctor
+        if self.supports_raw_conversation and "routing_key" not in body and \
                 self._user_is_proctor(message.username):
             self.log.info(f"Ignoring proctor message: {body=}")
             return

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -177,6 +177,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 self._user_is_proctor(message.username):
             self.log.info(f"Ignoring proctor message: {message.message_text}")
             return
+        if self._user_is_proctor(message.usewrname):
+            self.log.info(f"Received proctor message: {message.message_text}")
         self.handle_incoming_shout(message.model_dump())
 
     @create_mq_callback()

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -316,7 +316,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
         if "conversation_state" in message_data:
             self.set_conversation_state(cid, message_data['conversation_state'])
-            self.log.info(f"Conversation state from message data: {conversation_state}")
+            self.log.info(f"Conversation state from message data: "
+                          f"{self.get_conversation_state(cid)}")
         elif is_message_from_proctor:
             changed = False
             # Proctor cotrol message

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -19,6 +19,7 @@
 
 import os
 import time
+from typing import Dict
 
 from neon_mq_connector.utils import RepeatingTimer
 from neon_mq_connector.utils.rabbit_utils import create_mq_callback
@@ -42,7 +43,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         KlatAPIMQ.__init__(self, mq_config, service_name, vhost)
         ChatBotABC.__init__(self, service_name, bot_config)
         self.bot_type = bot_type
-        self.current_conversations = dict()
+
+        # Mapping of CID to context including `state` and `prompts`
+        self.current_conversations: Dict[str, dict] = dict()
         self.on_server = True
         self.default_response_queue = 'shout'
         self.shout_thread = RepeatingTimer(function=self._handle_next_shout,
@@ -55,7 +58,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         config: dict = config or kwargs.get('config', {})
         service_name: str = service_name or kwargs.get('service_name', 'undefined_service')
         vhost: str = vhost or kwargs.get('vhost', '/')
-        bot_type: repr(BotTypes) = bot_type or kwargs.get('bot_type', BotTypes.SUBMIND)
+        bot_type: BotTypes = bot_type or kwargs.get('bot_type', BotTypes.SUBMIND)
         return config, service_name, vhost, bot_type
 
     @create_mq_callback()
@@ -177,26 +180,28 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         # TODO: make it defaulting to True once all the related subminds are migrated (Kirill)
         return False
 
-    def get_chatbot_response(self, cid, message_data, shout, message_sender, is_message_from_proctor,
-                             conversation_state) -> dict:
+    def get_chatbot_response(self, cid: str, message_data: dict, shout: str,
+                             message_sender: str, is_message_from_proctor: bool,
+                             conversation_state: ConversationState) -> dict:
         """
-            Makes response based on incoming message data and its context
-            :param cid: current conversation id
-            :param message_data: message data received
-            :param shout: incoming shout data
-            :param message_sender: nick of message sender
-            :param is_message_from_proctor: is message sender a Proctor
-            :param conversation_state: state of the conversation from ConversationStates
+        Makes response based on incoming message data and its context
+        :param cid: current conversation id
+        :param message_data: message data received
+        :param shout: incoming shout data
+        :param message_sender: nick of message sender
+        :param is_message_from_proctor: is message sender a Proctor
+        :param conversation_state: state of the conversation
 
-            :returns response data as a dictionary, example:
-                {
-                 "shout": "I vote for Wolfram",
-                 "context": {"selected": "wolfram"},
-                 "queue": "pat_user_message"
-                }
+        :returns response data as a dictionary, example:
+            {
+                "shout": "I vote for Wolfram",
+                "context": {"selected": "wolfram"},
+                "queue": "pat_user_message"
+            }
         """
         response = {'shout': '', 'context': {}, 'queue': ''}
         self.log.info(f'Received incoming shout: {shout}')
+        self.log.info(f"message_data={message_data}")
         if self.contextual_api_supported:
             context_kwargs = {'context': self._build_submind_request_context(message_data=message_data,
                                                                              message_sender=message_sender,
@@ -220,16 +225,20 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                                                      shout=shout,
                                                      timestamp=str(message_data.get('timeCreated', int(time.time()))),
                                                      **context_kwargs)
+                # TODO: update `self.current_conversations['prompts']` with this new prompt ID and response
             elif conversation_state == ConversationState.DISC:
                 options: dict = message_data.get('proposed_responses', {})
                 response['shout'] = self.ask_discusser(options, **context_kwargs)
+                # TODO: update `self.current_conversations['prompts']` with these proposed responses
             elif conversation_state == ConversationState.VOTE:
+                # TODO: update `self.current_conversations['prompts']` with these votes
                 selected = self.ask_appraiser(options=message_data.get('proposed_responses', {}), **context_kwargs)
                 response['shout'] = self.vote_response(selected)
                 if 'abstain' in response['shout'].lower():
                     selected = "abstain"
                 response['context']['selected'] = selected
             elif conversation_state == ConversationState.WAIT:
+                # TODO: update `self.current_conversations['prompts']` with the selected response
                 response['shout'] = 'I am ready for the next prompt'
             response['context']['prompt_id'] = message_data.get('prompt_id', '')
         return response
@@ -447,10 +456,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         """
             Called recursively to handle incoming shouts synchronously
         """
-        next_message_data = self.shout_queue.get()
-        while next_message_data:
+        while next_message_data := self.shout_queue.get():
             self.handle_shout(next_message_data)
-            next_message_data = self.shout_queue.get()
 
     def _pause_responses(self, duration: int = 5):
         pass

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -466,7 +466,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             # repeated user as a signal that a new round of discussion started
             self.log.debug(f"{user} has started a new round of discussion")
             prompt_data["cycles"][-1]['discussion'].append({})
-        prompt_data['discussion'][-1][user] = shout
+        prompt_data["cycles"][-1]['discussion'][-1][user] = shout
 
     def on_vote(self, prompt_id: str, selected: str, voter: str):
         if prompt_id not in self.prompt_to_cid:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -314,7 +314,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         is_message_from_proctor = self._user_is_proctor(message_sender)
 
 
-        if conversation_state in message_data:
+        if "conversation_state" in message_data:
             self.set_conversation_state(cid, message_data['conversation_state'])
             self.log.info(f"Conversation state from message data: {conversation_state}")
         elif is_message_from_proctor:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -236,7 +236,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         cid = message.cid
         prompt_id = message.prompt_id
         context = {}  # TODO: Only used as a default for non-voting phases
-
+        response = None
+        
         # Initialize prompt data structure if it doesn't exist
         if prompt_id and prompt_id not in self.prompt_to_cid:
             self.current_conversations.setdefault(cid, {})

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -26,7 +26,7 @@ from neon_mq_connector.utils.rabbit_utils import create_mq_callback
 from klat_connector.mq_klat_api import KlatAPIMQ
 from pika.exchange_type import ExchangeType
 
-from chatbot_core.utils.enum import ConversationState, BotTypes
+from chatbot_core.utils.enum import ConversationState, BotTypes, CONVERSATION_STATE_ANNOUNCEMENTS
 from chatbot_core.chatbot_abc import ChatBotABC
 from chatbot_core.version import __version__ as package_version
 
@@ -277,6 +277,18 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     return {}
                 elif conversation_state == ConversationState.WAIT:
                     response['shout'] = 'I am ready for the next prompt'
+            elif is_message_from_proctor:
+                # Proctor cotrol message
+                # TODO: Better check here
+                if "accepting responses" in response['shout'].lower():
+                    self.set_conversation_state(cid, ConversationState.RESP)
+                elif "discussing responses" in response['shout'].lower():
+                    self.set_conversation_state(cid, ConversationState.DISC)
+                elif "voting for candidate responses" in response['shout'].lower():
+                    self.set_conversation_state(cid, ConversationState.VOTE)
+                elif response['shout'] == CONVERSATION_STATE_ANNOUNCEMENTS[
+                        ConversationState.PICK]:
+                    self.set_conversation_state(cid, ConversationState.PICK)
             else:
                 self.log.warning(f"No prompt id found in message data: "
                                  f"{message_data}")
@@ -313,17 +325,15 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
         # TODO: Patching Proctor message handling
         if conversation_state == ConversationState.IDLE and \
-            is_message_from_proctor and \
-                shout.startswith("The selected response"):
+                is_message_from_proctor:
             self.log.warning(f"Proctor specified idle state, but is a pick")
-            conversation_state = ConversationState.PICK
+            conversation_state = self.get_conversation_state(cid)
 
 
         if prompt_id := (message_data.get("promptID") or
                          message_data.get('prompt_id')) is not None and \
                 not is_message_from_proctor:
-            conversation_state = self.current_conversations.get(cid,
-                                                                 {}).get('state')
+            conversation_state = self.get_conversation_state(cid)
             self.log.info(f"Handling non-proctor CCAI message. state={conversation_state}")
             if conversation_state == ConversationState.RESP:
                 self.on_proposed_response(prompt_id, shout, message_sender)
@@ -570,7 +580,4 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         pass
 
     def ask_proctor(self, prompt: str, user: str, cid: str, dom: str):
-        pass
-
-    def on_proposed_response(self):
         pass

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -347,14 +347,15 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             if changed:
                 self.log.debug(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")
-        elif message.prompt_state:
+        elif message.prompt_state and \
+                message.prompt_state != ConversationState.IDLE:
             old_state = self.get_conversation_state(cid)
             self.set_conversation_state(cid, message.prompt_state)
             self.log.debug(f"Conversation state from message data: "
                           f"{self.get_conversation_state(cid)}")
             if self.get_conversation_state(cid) != old_state:
-                self.log.warning(
-                    f"Conversation state changed by Proctor message")
+                self.log.warning(f"Conversation state changed by Proctor "
+                                 f"message to {message.prompt_state}")
 
         conversation_state = self.get_conversation_state(cid)
         prompt_id = message.prompt_id
@@ -377,10 +378,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             try:
                 preamble, choice = shout.split(":", 1)
                 winner = preamble.split(" ")[-1]
+                self.on_selection(prompt_id, winner, choice)
             except ValueError:
                 self.log.warning(f"Failed to parse winner from: {shout}")
-                return
-            self.on_selection(prompt_id, winner, choice)
+            self.set_conversation_state(cid, ConversationState.IDLE)
         # elif conversation_state == ConversationState.RESP:
         #     # Proposal phase
         # elif conversation_state == ConversationState.DISC:
@@ -389,6 +390,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         #     # Voting phase
 
         elif shout:
+            self.log.info(f"Responding to {shout}")
             response = self.get_chatbot_response(cid=cid, message_data=message_data,
                                                  shout=shout, message_sender=message_sender,
                                                  is_message_from_proctor=is_message_from_proctor,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -175,7 +175,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         # `routing_key` check is a hack to exclude old messages from Proctor
         if self.supports_raw_conversation and "routing_key" not in body and \
                 self._user_is_proctor(message.username):
-            self.log.info(f"Ignoring proctor message: {body=}")
+            self.log.debug(f"Ignoring proctor message: {body=}")
             return
         if self._user_is_proctor(message.username):
             self.log.info(f"Received proctor message: {body=}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -198,6 +198,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             Handles an incoming shout into the current conversation
             :param message_data: data of incoming message
         """
+        if message_data.get("prompt_state") is not None and \
+            self.supports_raw_conversation:
+            # Raw conversation does not need the extra proctor messages
+            return
         self.shout_queue.put(message_data)
 
     @property

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -238,6 +238,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         prompt_id = message.prompt_id
         response = None
 
+        if message.requested_participants:
+            self.log.info(f"Got requested participants: {message}")
+
         # Initialize prompt data structure if it doesn't exist
         if prompt_id and prompt_id not in self.prompt_to_cid:
             # TODO: Participants were announced prior to this message
@@ -280,13 +283,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             elif "selecting a winner among participants" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.PICK)
-            elif "are selected for current prompt" in shout.lower():
-                self.log.info(f"Proctor selected next subminds: {shout}")
-                next_subminds = shout.split("are selected")[0].split(',')
-                next_subminds = [s.replace('and', '').strip() for s in next_subminds]
-                self.log.info(f"Proctor selected next subminds: {next_subminds}")
-                self.current_conversations.setdefault(cid, {})
-                self.current_conversations[cid]['next_subminds'] = next_subminds
             if changed:
                 self.log.debug(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -368,7 +368,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             context = {'selected': selected}
 
         if response:
-            self.log.info(f"Responding to {message}")
+            self.log.info(f"Responding to: {message.message_text}")
             response = ChatbotsMqSubmindResponse(
                 cid=message.cid,
                 user_id=self.uid,

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -232,6 +232,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             if not prompt_id and conversation_state != ConversationState.IDLE:
                 prompt_id = self.current_conversations[cid]['prompt_history'][-1]
                 self.log.info(f"Inferred prompt_id from history: {prompt_id}")
+
             if prompt_id:
                 # Initialize prompt data structure if it doesn't exist
                 if prompt_id not in self.current_conversations[cid]['prompts']:
@@ -280,15 +281,17 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             elif is_message_from_proctor:
                 # Proctor cotrol message
                 # TODO: Better check here
-                if "accepting responses" in response['shout'].lower():
+                if "accepting responses" in shout.lower():
                     self.set_conversation_state(cid, ConversationState.RESP)
-                elif "discussing responses" in response['shout'].lower():
+                elif "discussing responses" in shout.lower():
                     self.set_conversation_state(cid, ConversationState.DISC)
-                elif "voting for candidate responses" in response['shout'].lower():
+                elif "voting for candidate responses" in shout.lower():
                     self.set_conversation_state(cid, ConversationState.VOTE)
-                elif response['shout'] == CONVERSATION_STATE_ANNOUNCEMENTS[
+                elif shout == CONVERSATION_STATE_ANNOUNCEMENTS[
                         ConversationState.PICK]:
                     self.set_conversation_state(cid, ConversationState.PICK)
+                self.log.info(f"Proctor set state to: "
+                              f"{self.get_conversation_state(cid)}")
             else:
                 self.log.warning(f"No prompt id found in message data: "
                                  f"{message_data}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -368,7 +368,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             context = {'selected': selected}
 
         if response:
-            self.log.info(f"Responding to {message.message_text}")
+            self.log.info(f"Responding to {message}")
             response = ChatbotsMqSubmindResponse(
                 cid=message.cid,
                 user_id=self.uid,
@@ -386,7 +386,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             )
             self.send_shout(responded_message=response.replied_message,
                             **response.model_dump())
-            self.log.info(f"Sent response:{response}")
+            self.log.debug(f"Sent response:{response}")
         else:
             self.log.warning(
                 f'No response generated with state={conversation_state.name} '

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -278,20 +278,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     return {}
                 elif conversation_state == ConversationState.WAIT:
                     response['shout'] = 'I am ready for the next prompt'
-            elif is_message_from_proctor:
-                # Proctor cotrol message
-                # TODO: Better check here
-                if "accepting responses" in shout.lower():
-                    self.set_conversation_state(cid, ConversationState.RESP)
-                elif "discussing responses" in shout.lower():
-                    self.set_conversation_state(cid, ConversationState.DISC)
-                elif "voting for candidate responses" in shout.lower():
-                    self.set_conversation_state(cid, ConversationState.VOTE)
-                elif shout == CONVERSATION_STATE_ANNOUNCEMENTS[
-                        ConversationState.PICK]:
-                    self.set_conversation_state(cid, ConversationState.PICK)
-                self.log.info(f"Proctor set state to: "
-                              f"{self.get_conversation_state(cid)}")
             else:
                 self.log.warning(f"No prompt id found in message data: "
                                  f"{message_data}")
@@ -320,17 +306,26 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         self.log.debug(f'Message data: {message_data}')
         shout = message_data.get('shout') or message_data.get('messageText', '')
         cid = message_data.get('cid', '')
+        # TODO: Refactor to track this internally instead of from message context
         conversation_state = ConversationState(message_data.get('conversation_state', 0))
 
         message_sender = message_data.get('nick') or \
             message_data.get('userDisplayName', 'anonymous')
         is_message_from_proctor = self._user_is_proctor(message_sender)
 
-        # TODO: Patching Proctor message handling
-        if conversation_state == ConversationState.IDLE and \
-                is_message_from_proctor:
-            self.log.warning(f"Proctor specified idle state, but is a pick")
-            conversation_state = self.get_conversation_state(cid)
+        if is_message_from_proctor:
+            # Proctor cotrol message
+            # TODO: Better check here
+            if "accepting responses" in shout.lower():
+                self.set_conversation_state(cid, ConversationState.RESP)
+            elif "discussing responses" in shout.lower():
+                self.set_conversation_state(cid, ConversationState.DISC)
+            elif "voting for candidate responses" in shout.lower():
+                self.set_conversation_state(cid, ConversationState.VOTE)
+            elif "the selected response if from" in shout.lower():
+                self.set_conversation_state(cid, ConversationState.PICK)
+            self.log.info(f"Proctor set state to: "
+                            f"{self.get_conversation_state(cid)}")
 
         prompt_id = message_data.get("promptID") or message_data.get('prompt_id')
         if prompt_id and not is_message_from_proctor:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -313,7 +313,11 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             message_data.get('userDisplayName', 'anonymous')
         is_message_from_proctor = self._user_is_proctor(message_sender)
 
-        if is_message_from_proctor:
+
+        if conversation_state in message_data:
+            self.set_conversation_state(cid, message_data['conversation_state'])
+            self.log.info(f"Conversation state from message data: {conversation_state}")
+        elif is_message_from_proctor:
             # Proctor cotrol message
             # TODO: Better check here
             if "accepting responses" in shout.lower():
@@ -322,14 +326,14 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 self.set_conversation_state(cid, ConversationState.DISC)
             elif "voting for candidate responses" in shout.lower():
                 self.set_conversation_state(cid, ConversationState.VOTE)
-            elif "the selected response if from" in shout.lower():
+            elif "the selected response is from" in shout.lower():
                 self.set_conversation_state(cid, ConversationState.PICK)
-            self.log.info(f"Proctor set state to: "
-                            f"{self.get_conversation_state(cid)}")
+            self.log.info(f"Conversation state from proctor shout: "
+                          f"{self.get_conversation_state(cid)}")
 
         conversation_state = self.get_conversation_state(cid)
         prompt_id = message_data.get("promptID") or message_data.get('prompt_id')
-        
+
         if prompt_id and not is_message_from_proctor:
             self.log.info(f"Handling non-proctor CCAI message. state={conversation_state}")
             if conversation_state == ConversationState.RESP:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -337,8 +337,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             if changed:
                 self.log.info(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")
-            # Proctor messages without a state context should be ignored
-            return
+                # Proctor message has no other purpose
+                return
 
         conversation_state = self.get_conversation_state(cid)
         prompt_id = message_data.get("promptID") or message_data.get('prompt_id')

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -314,6 +314,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     self.log.info(f"Proctor selected next subminds: {next_subminds}")
                     self.current_conversations.setdefault(cid, {})
                     self.current_conversations[cid]['next_subminds'] = next_subminds
+                else:
+                    self.log.warning(f"Not handling proctor message: {shout}")
                 return
             # Non-proctored conversation activity
             self.log.info(f"Non-proctored input: {message}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -236,7 +236,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         shout = message.message_text
         cid = message.cid
         prompt_id = message.prompt_id
-        context = {}  # TODO: Only used as a default for non-voting phases
         response = None
 
         # Initialize prompt data structure if it doesn't exist
@@ -365,7 +364,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             response = self.vote_response(selected)
             if 'abstain' in response.lower():
                 selected = "abstain"
-            context = {'selected': selected}
 
         if response:
             self.log.info(f"Responding to: {message.message_text}")
@@ -380,7 +378,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 source="chatbot",
                 to_discussion=True,
                 prompt_state=conversation_state,
-                # context=context,
                 omit_reply=False,
                 no_save=False
             )

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -149,7 +149,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                            f"{body.get('messageID')}")
             return
         if body.get('cid') not in list(self.current_conversations):
-            self.log.info(f"Ignoring message "
+            self.log.debug(f"Ignoring message "
                           f"(messageID={body.get('messageID')}) outside of "
                           f"current conversations "
                           f"({self.current_conversations})")
@@ -204,7 +204,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             }
         """
         response = {'shout': '', 'context': {}, 'queue': ''}
-        self.log.info(f'Received incoming shout from: {message_sender}. '
+        self.log.debug(f'Received incoming shout from: {message_sender}. '
                       f' state={conversation_state}|shout={shout}')
         if self.contextual_api_supported:
             context_kwargs = {'context': self._build_submind_request_context(message_data=message_data,
@@ -313,10 +313,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             message_data.get('userDisplayName', 'anonymous')
         is_message_from_proctor = self._user_is_proctor(message_sender)
 
-
+        # TODO: Refactor to not rely on `conversation_state` context proctor ctx
         if "conversation_state" in message_data:
             self.set_conversation_state(cid, message_data['conversation_state'])
-            self.log.info(f"Conversation state from message data: "
+            self.log.debug(f"Conversation state from message data: "
                           f"{self.get_conversation_state(cid)}")
         elif is_message_from_proctor:
             changed = False
@@ -335,7 +335,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 changed = True
                 self.set_conversation_state(cid, ConversationState.PICK)
             if changed:
-                self.log.info(f"Conversation state set from proctor shout: "
+                self.log.debug(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")
                 # Proctor message has no other purpose
                 return
@@ -344,7 +344,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         prompt_id = message_data.get("promptID") or message_data.get('prompt_id')
 
         if prompt_id and not is_message_from_proctor:
-            self.log.info(f"Handling non-proctor CCAI message. state={conversation_state}")
+            self.log.debug(f"Handling non-proctor CCAI message. state={conversation_state}")
             if conversation_state == ConversationState.RESP:
                 self.on_proposed_response(prompt_id, shout, message_sender)
             elif conversation_state == ConversationState.DISC:
@@ -380,9 +380,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
     def _send_state(self):
         self.send_shout(shout='chatbot state',
                         context={
+                            'service_name': self.service_name,
                             'version': os.environ.get('SERVICE_VERSION', package_version),
                             'bot_type': self.bot_type,
-                            'supports_raw_shouts': True,  # TODO: infer from version OR make this optional per-submind
+                            'supports_raw_conversation': True,  # TODO: infer from version OR make this optional per-submind
                             'cids': list(self.current_conversations),
                         },
                         exchange='connection')
@@ -433,7 +434,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
             return
         prompt_data['proposed_responses'][user] = response
-        self.log.info(f"Received proposed response from {user}: {response}")  # TODO debug
+        self.log.debug(f"Received proposed response from {user}: {response}")
 
     def on_discussion(self, user: str, shout: str, prompt_id: str):
         if prompt_id not in self.prompt_to_cid:
@@ -461,8 +462,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
             return
         prompt_data['votes'][voter] = selected
-        self.log.info(f"Received vote from {voter}: {selected}")  # TODO debug
+        self.log.debug(f"Received vote from {voter}: {selected}")
 
+    # TODO: Implement below methods in place of handling in `get_chatbot_response`
     def on_selection(self, prompt: str, user: str, response: str):
         pass
 

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -173,7 +173,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.debug(f"{body}")
             return
         if self.supports_raw_conversation and \
-                message.requested_participants is not None and \
+                message.requested_participants is None and \
                 self._user_is_proctor(message.username):
             self.log.info(f"Ignoring targeted message: {message.message_text}")
             return
@@ -282,12 +282,12 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             if changed:
                 self.log.debug(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")
-            if not changed and message.prompt_state \
-                    and message.prompt_state != ConversationState.IDLE:
+            if not changed and \
+                    message.prompt_state not in (None, ConversationState.IDLE):
                 old_state = self.get_conversation_state(cid)
                 self.set_conversation_state(cid, message.prompt_state)
-                self.log.debug(f"Conversation state from message data: "
-                            f"{self.get_conversation_state(cid)}")
+                self.log.warning(f"Conversation state from message data: "
+                                 f"{self.get_conversation_state(cid)}")
                 if self.get_conversation_state(cid) != old_state:
                     self.log.warning(f"Conversation state changed by Proctor "
                                     f"message to {message.prompt_state}")
@@ -388,7 +388,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                             is_announcement=response.is_announcement,
                             prompt_id=response.prompt_id)
         else:
-            self.log.warning(f'No response generated for message data: {message_data}')
+            self.log.warning(
+                f'No response generated with state={conversation_state.name} '
+                f'{message_data=}.')
 
     def _send_state(self):
         self.send_shout(shout='chatbot state',

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -173,7 +173,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.debug(f"{body}")
             return
         if self.supports_raw_conversation and \
-                message.requested_participants and \
                 message.prompt_state is not None and \
                 self._user_is_proctor(message.username):
             self.log.info(f"Ignoring proctor message: {message.message_text}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -46,6 +46,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
 
         # Mapping of CID to context including `state` and `prompts`
         self.current_conversations: Dict[str, dict] = dict()
+        # Mapping of prompt_id to associated CID
+        self.prompt_to_cid = Dict[str, str] = dict()
         self.on_server = True
         self.default_response_queue = 'shout'
         self.shout_thread = RepeatingTimer(function=self._handle_next_shout,
@@ -202,8 +204,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             }
         """
         response = {'shout': '', 'context': {}, 'queue': ''}
-        self.log.info(f'Received incoming shout: {shout}')
-        self.log.info(f"message_data={message_data}")
+        self.log.info(f'Received incoming shout: {shout} '
+                      f'FROM: {message_sender}')
         if self.contextual_api_supported:
             context_kwargs = {'context': self._build_submind_request_context(message_data=message_data,
                                                                              message_sender=message_sender,
@@ -221,27 +223,52 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             response['conversation_state'] = conversation_state
             message_sender = BotTypes.PROCTOR
 
+            self.current_conversations.setdefault(cid, {})
+            self.current_conversations[cid].setdefault("prompts", {})
+            self.current_conversations[cid].setdefault("prompt_history", [])
+            prompt_id = message_data.get('prompt_id', '')
             self.set_conversation_state(cid, conversation_state)
-            if conversation_state == ConversationState.RESP:
-                response['shout'] = self.ask_chatbot(user=message_sender,
-                                                     shout=shout,
-                                                     timestamp=str(message_data.get('timeCreated', int(time.time()))),
-                                                     **context_kwargs)
-                # TODO: update `self.current_conversations['prompts']` with this new prompt ID and response
-            elif conversation_state == ConversationState.DISC:
-                options: dict = message_data.get('proposed_responses', {})
-                response['shout'] = self.ask_discusser(options, **context_kwargs)
-                # TODO: update `self.current_conversations['prompts']` with these proposed responses
-            elif conversation_state == ConversationState.VOTE:
-                # TODO: update `self.current_conversations['prompts']` with these votes
-                selected = self.ask_appraiser(options=message_data.get('proposed_responses', {}), **context_kwargs)
-                response['shout'] = self.vote_response(selected)
-                if 'abstain' in response['shout'].lower():
-                    selected = "abstain"
-                response['context']['selected'] = selected
-            elif conversation_state == ConversationState.WAIT:
-                # TODO: update `self.current_conversations['prompts']` with the selected response
-                response['shout'] = 'I am ready for the next prompt'
+            if prompt_id:
+                # Initialize prompt data structure if it doesn't exist
+                if prompt_id not in self.current_conversations[cid]['prompts']:
+                    self.current_conversations[cid]['prompts'][prompt_id] = {
+                        "proposed_responses": {},
+                        "discussion": [{}],
+                        "votes": {}
+                    }
+                current_prompt = self.current_conversations[cid]['prompts'][prompt_id]
+                self.current_conversations[cid]['prompt_history'].append(prompt_id)
+                self.prompt_to_cid[prompt_id] = cid
+
+                # TODO: Include prompt history in context
+                if conversation_state == ConversationState.RESP:
+                    response['shout'] = self.ask_chatbot(user=message_sender,
+                                                         shout=shout,
+                                                         timestamp=str(message_data.get('timeCreated', int(time.time()))),
+                                                         **context_kwargs)
+                    current_prompt["prompt"] = message_data.get('shout', '')
+                    current_prompt["proposal"] = response['shout']
+                    current_prompt["participating_subminds"] = message_data.get(
+                        'participating_subminds', [])
+                elif conversation_state == ConversationState.DISC:
+                    current_prompt.setdefault("discussion", [{}])
+                    # TODO: Get `proposed_responses` from internal reference
+                    options: dict = message_data.get('proposed_responses', {})
+                    current_prompt['proposed_responses'] = options
+                    response['shout'] = self.ask_discusser(options, **context_kwargs)
+                elif conversation_state == ConversationState.VOTE:
+                    # TODO: Get `proposed_responses` from internal reference
+                    options = message_data.get('proposed_responses', {})
+                    selected = self.ask_appraiser(options=options, **context_kwargs)
+                    response['shout'] = self.vote_response(selected)
+                    if 'abstain' in response['shout'].lower():
+                        selected = "abstain"
+                    response['context']['selected'] = selected
+                    current_prompt['selected'] = selected
+                elif conversation_state == ConversationState.WAIT:
+                    current_prompt["response"] = shout
+                    self.log.info(f"Completed prompt: {current_prompt}")
+                    response['shout'] = 'I am ready for the next prompt'
             response['context']['prompt_id'] = message_data.get('prompt_id', '')
         return response
 
@@ -270,7 +297,17 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         conversation_state = ConversationState(message_data.get('conversation_state', 0))
         message_sender = message_data.get('nick', 'anonymous')
         is_message_from_proctor = self._user_is_proctor(message_sender)
-        if shout:
+        if prompt_id := message_data.get("prompt_id") is not None and \
+                not is_message_from_proctor:
+            self.log.info("Handling non-proctor CCAI message")  # TODO: log.debug
+            if conversation_state == ConversationState.RESP:
+                self.on_proposed_response(prompt_id, shout, message_sender)
+            elif conversation_state == ConversationState.DISC:
+                self.on_discussion(message_sender, shout, prompt_id)
+            elif conversation_state == ConversationState.VOTE:
+                self.on_vote(prompt_id, shout, message_sender)
+
+        elif shout:
             response = self.get_chatbot_response(cid=cid, message_data=message_data,
                                                  shout=shout, message_sender=message_sender,
                                                  is_message_from_proctor=is_message_from_proctor,
@@ -300,6 +337,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                         context={
                             'version': os.environ.get('SERVICE_VERSION', package_version),
                             'bot_type': self.bot_type,
+                            'supports_raw_shouts': True,  # TODO: infer from version OR make this optional per-submind
                             'cids': list(self.current_conversations),
                         },
                         exchange='connection')
@@ -340,14 +378,45 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         elif not shout:
             self.log.warning(f"Empty discussion provided! ({self.nick})")
 
+    def on_proposed_response(self, prompt_id: str, response: str, user: str):
+        if prompt_id not in self.prompt_to_cid:
+            self.log.warning(f"Unknown prompt id: {prompt_id}")
+            return
+        prompt_data = self.current_conversations[self.prompt_to_cid[prompt_id]]\
+            .get('prompts', {}).get(prompt_id, {})
+        if not prompt_data:
+            self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
+            return
+        prompt_data['proposed_responses'][user] = response
+        self.log.info(f"Received proposed response from {user}: {response}")  # TODO debug
+
+    def on_discussion(self, user: str, shout: str, prompt_id: str):
+        if prompt_id not in self.prompt_to_cid:
+            self.log.warning(f"Unknown prompt id: {prompt_id}")
+            return
+        prompt_data = self.current_conversations[self.prompt_to_cid[prompt_id]]\
+            .get('prompts', {}).get(prompt_id, {})
+        if not prompt_data:
+            self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
+            return
+        if user in prompt_data['discussion'][-1]:
+            # Users can only send one discussion message per round. Use this
+            # repeated user as a signal that a new round of discussion started
+            self.log.debug(f"{user} has started a new round of discussion")
+            prompt_data['discussion'].append({})
+        prompt_data['discussion'][-1][user] = shout
+
     def on_vote(self, prompt_id: str, selected: str, voter: str):
-        pass
-
-    def on_discussion(self, user: str, shout: str):
-        pass
-
-    def on_proposed_response(self):
-        pass
+        if prompt_id not in self.prompt_to_cid:
+            self.log.warning(f"Unknown prompt id: {prompt_id}")
+            return
+        prompt_data = self.current_conversations[self.prompt_to_cid[prompt_id]]\
+            .get('prompts', {}).get(prompt_id, {})
+        if not prompt_data:
+            self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
+            return
+        prompt_data['votes'][voter] = selected
+        self.log.info(f"Received vote from {voter}: {selected}")  # TODO debug
 
     def on_selection(self, prompt: str, user: str, response: str):
         pass
@@ -358,22 +427,13 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
     def at_chatbot(self, user: str, shout: str, timestamp: str) -> str:
         pass
 
-    def ask_proctor(self, prompt: str, user: str, cid: str, dom: str):
-        pass
-
     def ask_chatbot(self, user: str, shout: str, timestamp: str, context: dict = None) -> str:
-        pass
-
-    def ask_history(self, user: str, shout: str, dom: str, cid: str) -> str:
         pass
 
     def ask_appraiser(self, options: dict, context: dict = None) -> str:
         pass
 
     def ask_discusser(self, options: dict, context: dict = None) -> str:
-        pass
-
-    def _send_first_prompt(self):
         pass
 
     def send_shout(self, shout, responded_message=None, cid: str = '', dom: str = '',
@@ -476,3 +536,16 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
     def stop(self):
         self.stop_shout_thread()
         KlatAPIMQ.stop(self)
+
+# Unimplemented Abstract Methods
+    def _send_first_prompt(self):
+        pass
+
+    def ask_history(self, user: str, shout: str, dom: str, cid: str) -> str:
+        pass
+
+    def ask_proctor(self, prompt: str, user: str, cid: str, dom: str):
+        pass
+
+    def on_proposed_response(self):
+        pass

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -270,8 +270,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     response['context']['selected'] = selected
                     current_prompt['selected'] = selected
                 elif conversation_state == ConversationState.PICK:
-                    preamble, response = shout.split(":", 1)
-                    current_prompt["response"] = response.strip().strip('"')
+                    preamble, choice = shout.split(":", 1)
+                    current_prompt["response"] = choice.strip().strip('"')
                     current_prompt["winner"] = preamble.split(" ")[-1]
                     self.log.info(f"Completed prompt: {current_prompt}")
                     return {}
@@ -322,7 +322,9 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         if prompt_id := (message_data.get("promptID") or
                          message_data.get('prompt_id')) is not None and \
                 not is_message_from_proctor:
-            self.log.debug("Handling non-proctor CCAI message")
+            conversation_state = self.current_conversations.get(cid,
+                                                                 {}).get('state')
+            self.log.info(f"Handling non-proctor CCAI message. state={conversation_state}")
             if conversation_state == ConversationState.RESP:
                 self.on_proposed_response(prompt_id, shout, message_sender)
             elif conversation_state == ConversationState.DISC:

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -237,7 +237,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         prompt_id = message.prompt_id
         context = {}  # TODO: Only used as a default for non-voting phases
         response = None
-        
+
         # Initialize prompt data structure if it doesn't exist
         if prompt_id and prompt_id not in self.prompt_to_cid:
             self.current_conversations.setdefault(cid, {})
@@ -245,11 +245,13 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.current_conversations[cid].setdefault("prompt_history", [])
             if prompt_id not in self.current_conversations[cid]['prompts']:
                 self.current_conversations[cid]['prompts'][prompt_id] = {
-                    "bot_name": self.nick,
+                    "bot_name": self.service_name,
                     "participating_subminds": [],
-                    "proposed_responses": {},
-                    "discussion": [{}],
-                    "votes": {}
+                    "cycles": [{
+                        "proposed_responses": {},
+                        "discussion": [{}],
+                        "votes": {}
+                    }]
                 }
             self.current_conversations[cid]['prompt_history'].append(prompt_id)
             self.prompt_to_cid[prompt_id] = cid
@@ -331,6 +333,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 self.on_discussion(message_sender, shout, prompt_id)
             elif conversation_state == ConversationState.VOTE:
                 self.on_vote(prompt_id, shout, message_sender)
+            return
         elif conversation_state == ConversationState.PICK:
             # Proctor made a selection
             try:
@@ -340,6 +343,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             except ValueError:
                 self.log.warning(f"Failed to parse winner from: {shout}")
             self.set_conversation_state(cid, ConversationState.IDLE)
+            return
         elif conversation_state == ConversationState.RESP:
             # Proposal phase
             self.current_conversations[cid]['prompts'][prompt_id]\
@@ -348,15 +352,15 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                                         shout=shout,
                                         timestamp=str(message.time_created.timestamp()))
             # TODO: Remove `proposal` as it is per-cycle
-            current_prompt["proposal"] = response
+            current_prompt["cycles"][-1]["proposal"] = response
         elif conversation_state == ConversationState.DISC:
             # Discussion phase
-            options: dict = current_prompt.get('proposed_responses', {})
-            current_prompt['proposed_responses'] = options
+            options: dict = current_prompt["cycles"][-1].get('proposed_responses', {})
+            current_prompt["cycles"][-1]['proposed_responses'] = options
             response = self.ask_discusser(options)
         elif conversation_state == ConversationState.VOTE:
             # Voting phase
-            options: dict = current_prompt.get('proposed_responses', {})
+            options: dict = current_prompt["cycles"][-1].get('proposed_responses', {})
             selected = self.ask_appraiser(options=options)
             response = self.vote_response(selected)
             if 'abstain' in response.lower():
@@ -445,7 +449,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             return
         if user not in prompt_data['participating_subminds']:
             prompt_data['participating_subminds'].append(user)
-        prompt_data['proposed_responses'][user] = response
+        prompt_data["cycles"][-1]['proposed_responses'][user] = response
         self.log.debug(f"Received proposed response from {user}: {response}")
 
     def on_discussion(self, user: str, shout: str, prompt_id: str):
@@ -461,7 +465,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             # Users can only send one discussion message per round. Use this
             # repeated user as a signal that a new round of discussion started
             self.log.debug(f"{user} has started a new round of discussion")
-            prompt_data['discussion'].append({})
+            prompt_data["cycles"][-1]['discussion'].append({})
         prompt_data['discussion'][-1][user] = shout
 
     def on_vote(self, prompt_id: str, selected: str, voter: str):
@@ -473,7 +477,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         if not prompt_data:
             self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
             return
-        prompt_data['votes'][voter] = selected
+        prompt_data["cycles"][-1]['votes'][voter] = selected
         self.log.debug(f"Received vote from {voter}: {selected}")
 
     def on_selection(self, prompt_id: str, user: str, response: str):

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -353,8 +353,6 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             response = self.ask_chatbot(user=message_sender,
                                         shout=shout,
                                         timestamp=str(message.time_created.timestamp()))
-            # TODO: Remove `proposal` as it is per-cycle
-            current_prompt["cycles"][-1]["proposal"] = response
         elif conversation_state == ConversationState.DISC:
             # Discussion phase
             options: dict = current_prompt["cycles"][-1].get('proposed_responses', {})
@@ -382,7 +380,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 source="chatbot",
                 to_discussion=True,
                 prompt_state=conversation_state,
-                context=context,
+                # context=context,
                 omit_reply=False,
                 no_save=False
             )

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -386,8 +386,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             )
             self.send_shout(responded_message=response.replied_message,
                             **response.model_dump())
-            self.log.info(f"Sent response to {response.cid}: "
-                          f"{response.message_text} ")
+            self.log.info(f"Sent response:{response}")
         else:
             self.log.warning(
                 f'No response generated with state={conversation_state.name} '

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -204,8 +204,8 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             }
         """
         response = {'shout': '', 'context': {}, 'queue': ''}
-        self.log.info(f'Received incoming shout: {shout} '
-                      f'FROM: {message_sender}')
+        self.log.info(f'Received incoming shout from: {message_sender}. '
+                      f' state={conversation_state}|shout={shout}')
         if self.contextual_api_supported:
             context_kwargs = {'context': self._build_submind_request_context(message_data=message_data,
                                                                              message_sender=message_sender,
@@ -291,7 +291,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             :param message_data: dict containing message data received
             :param skip_callback: to skip callback after handling shout (default to False)
         """
-        self.log.info(f'Message data: {message_data}')
+        self.log.debug(f'Message data: {message_data}')
         shout = message_data.get('shout') or message_data.get('messageText', '')
         cid = message_data.get('cid', '')
         conversation_state = ConversationState(message_data.get('conversation_state', 0))

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -280,6 +280,13 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             elif "selecting a winner among participants" in shout.lower():
                 changed = True
                 self.set_conversation_state(cid, ConversationState.PICK)
+            elif "are selected for current prompt" in shout.lower():
+                self.log.info(f"Proctor selected next subminds: {shout}")
+                next_subminds = shout.split("are selected")[0].split(',')
+                next_subminds = [s.replace('and', '').strip() for s in next_subminds]
+                self.log.info(f"Proctor selected next subminds: {next_subminds}")
+                self.current_conversations.setdefault(cid, {})
+                self.current_conversations[cid]['next_subminds'] = next_subminds
             if changed:
                 self.log.debug(f"Conversation state set from proctor shout: "
                             f"{self.get_conversation_state(cid)}")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -174,6 +174,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             return
         if self.supports_raw_conversation and \
                 message.requested_participants and \
+                message.prompt_state is not None and \
                 self._user_is_proctor(message.username):
             self.log.info(f"Ignoring proctor message: {message.message_text}")
             return

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -461,7 +461,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
         if not prompt_data:
             self.log.error(f"prompt data unexpectedly None for id={prompt_id}")
             return
-        if user in prompt_data['discussion'][-1]:
+        if user in prompt_data["cycles"][-1]['discussion'][-1]:
             # Users can only send one discussion message per round. Use this
             # repeated user as a signal that a new round of discussion started
             self.log.debug(f"{user} has started a new round of discussion")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -173,7 +173,7 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
             self.log.debug(f"{body}")
             return
         if self.supports_raw_conversation and \
-                message.requested_participants is None and \
+                message.requested_participants and \
                 self._user_is_proctor(message.username):
             self.log.info(f"Ignoring proctor message: {message.message_text}")
             return
@@ -380,10 +380,11 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                 source="chatbot",
                 to_discussion=True,
                 prompt_state=conversation_state,
-                context=context
+                context=context,
+                omit_reply=False,
+                no_save=False
             )
-            self.send_shout(shout=response.message_text,
-                            responded_message=response.replied_message,
+            self.send_shout(responded_message=response.replied_message,
                             **response.model_dump())
             self.log.info(f"Sent response to {response.cid}: "
                           f"{response.message_text} ")

--- a/chatbot_core/v2/__init__.py
+++ b/chatbot_core/v2/__init__.py
@@ -296,8 +296,10 @@ class ChatBot(KlatAPIMQ, ChatBotABC):
                     self.log.warning(f"Conversation state changed by Proctor "
                                     f"message to {message.prompt_state}")
                     changed = True
-            if prompt_id and "participating_subminds" in message_data:
+            if prompt_id and ("participating_subminds" in message_data):
                 self.log.info(f"Got participants from: {message_data}")
+            elif prompt_id and ("requested_subminds" in message_data):
+                self.log.info(f"Got requested participants from: {message_data}")
         if changed:
             self.log.info(f"State changed to: "
                           f"{self.get_conversation_state(cid).name}")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,3 +4,4 @@ neon-mq-connector~=0.8
 neon-utils[network,sentry]~=1.12
 ovos-bus-client~=0.0,>=0.0.5
 psutil~=5.7
+neon-data-models~=0.0,>=0.0.2a2


### PR DESCRIPTION
# Description
Update docstrings and annotations
Add internal tracking of `prompt_to_cid`
Update logging
Add handling for non-proctor conversation messages
Update state messages to include `service_name` and `supports_raw_conversation`

# Issues
- Closes https://github.com/NeonGeckoCom/pyklatchat/issues/140
- Needs https://github.com/NeonGeckoCom/mq-chatbots-observer/pull/37

# Other Notes
- Deployed with `wiz` to the Alpha namespace
- It may be worth implementing this as a "v3" chatbot class if we want to allow "v2" chatbots to continue using existing Proctor context