### PR TITLE
Support multiple `discussion` rounds with unit test

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -9,4 +9,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(bs4|nvidia|bitstruct|audioread|klat-connector|neon-chatbot-core|tqdm|dnspython|RapidFuzz|typing_extensions|wheel).*'
+      packages-exclude: '^(bs4|nvidia|bitstruct|audioread|klat-connector|neon-chatbot-core|tqdm|dnspython|RapidFuzz|typing_extensions|wheel|urllib).*'

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -9,4 +9,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(bs4|nvidia|bitstruct|audioread|klat-connector|neon-chatbot-core|tqdm|dnspython|RapidFuzz).*'
+      packages-exclude: '^(bs4|nvidia|bitstruct|audioread|klat-connector|neon-chatbot-core|tqdm|dnspython|RapidFuzz|typing_extensions|wheel).*'

--- a/chatbot_core/utils/conversation_utils.py
+++ b/chatbot_core/utils/conversation_utils.py
@@ -20,12 +20,15 @@
 from itertools import cycle
 
 
-def create_conversation_cycle() -> cycle:
+def create_conversation_cycle(discussion_rounds: int = 1) -> cycle:
     """Cycle through conversation states"""
     from chatbot_core.utils.enum import ConversationState
 
-    return cycle([ConversationState.RESP,
-                  ConversationState.DISC,
-                  ConversationState.VOTE,
-                  ConversationState.PICK,
-                  ConversationState.IDLE])
+
+    flow = [ConversationState.RESP] + \
+        [ConversationState.DISC] * discussion_rounds + \
+        [ConversationState.VOTE,
+         ConversationState.PICK,
+         ConversationState.IDLE]
+
+    return cycle(flow)

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -189,6 +189,17 @@ class TestConversationUtils(unittest.TestCase):
         self.assertEqual(next(convo), ConversationState.IDLE)
         self.assertEqual(next(convo), ConversationState.RESP)
 
+        # Multi-discussion
+        cycle = create_conversation_cycle(2)
+        self.assertEqual(next(cycle), ConversationState.RESP)
+        self.assertEqual(next(cycle), ConversationState.DISC)
+        self.assertEqual(next(cycle), ConversationState.DISC)
+        self.assertEqual(next(cycle), ConversationState.VOTE)
+        self.assertEqual(next(cycle), ConversationState.PICK)
+        self.assertEqual(next(cycle), ConversationState.IDLE)
+        self.assertEqual(next(cycle), ConversationState.RESP)
+
+
 
 class TestEnum(unittest.TestCase):
     def test_conversation_controls(self):


### PR DESCRIPTION
# Description
Adds an option to create a conversation cycle with multiple `discuss` phases

# Issues
- Related to https://github.com/NeonGeckoCom/pyklatchat/issues/139
- Implemented by https://github.com/NeonGeckoCom/chat-facilitator-proctor/pull/20

# Other Notes
Tested with Proctor currently deployed to alpha